### PR TITLE
fix: error with gfa export of fully duplicated paths

### DIFF
--- a/src/gfa.jl
+++ b/src/gfa.jl
@@ -143,6 +143,10 @@ function marshal_gfa(io::IO, G::Graph; opt=nothing)
         ]
         filter!(n->n!==nothing, nodes)
 
+        if length(nodes) == 0
+            continue
+        end
+
         for (j,node) in enumerate(nodes[2:end])
             addlink!(nodes[j], node)
         end
@@ -170,8 +174,10 @@ function marshal_gfa(io::IO, G::Graph; opt=nothing)
     end
 
     write(io, "# sequences\n")
-    for path in values(paths)
-        write(io,"$(path)\n")
+    for i = 1:length(paths)
+        if isassigned(paths, i)
+            write(io, "$(paths[i])\n")
+        end
     end
 end
 


### PR DESCRIPTION
Fixes an error that would come up when exporting to gfa format with the `--no-duplications` flag, if one of the paths is composed of only duplicated blocks.
In this case the list of exported nodes is empty, and I would hit the error in line 151 of the old version, when `nodes[1]` was called.
I fixed it by simply avoid defining the path if no nodes are exported, and later avoid writing a path to file if undefined.