### PR TITLE
feat: errors are emitted from asyncronous tasks

### DIFF
--- a/src/align.jl
+++ b/src/align.jl
@@ -649,8 +649,8 @@ function align(Gs::Graph...; compare=Mash.distance, energy=(hit)->(-Inf), minblo
         end
     end
 
-    for clade ∈ postorder(tree)
-        @spawn try
+    @sync for clade ∈ postorder(tree)
+        @spawn begin
             if isleaf(clade)
                 close(clade.graph)
                 put!(clade.parent.graph, tips[clade.name])
@@ -670,8 +670,6 @@ function align(Gs::Graph...; compare=Mash.distance, energy=(hit)->(-Inf), minblo
                     put!(result, G₀); close(result)
                 end
             end
-        catch e
-            error(e)
         end
     end
 

--- a/src/align.jl
+++ b/src/align.jl
@@ -649,6 +649,7 @@ function align(Gs::Graph...; compare=Mash.distance, energy=(hit)->(-Inf), minblo
         end
     end
 
+    G = nothing
     @sync for clade ∈ postorder(tree)
         @spawn begin
             if isleaf(clade)
@@ -667,14 +668,13 @@ function align(Gs::Graph...; compare=Mash.distance, energy=(hit)->(-Inf), minblo
                 if clade.parent !== nothing
                     put!(clade.parent.graph, G₀)
                 else
-                    put!(result, G₀); close(result)
+                    G = G₀
                 end
             end
         end
     end
-
-    G = take!(result)
     close(events)
+
     return G
 end
 

--- a/src/align.jl
+++ b/src/align.jl
@@ -640,7 +640,6 @@ function align(Gs::Graph...; compare=Mash.distance, energy=(hit)->(-Inf), minblo
     log("--> aligning pairs")
 
     events = Channel{Bool}(10);
-    result = Channel{Graph}(1);
 
     @spawn let
         while isopen(events)


### PR DESCRIPTION
In the `align` function (`align.jl`)
-  added `@sync` macro on the loop in which threads are spawned.
- removed the try-catch (obsolete?)