### PR TITLE
chore(ci): build and deploy docs automatically

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,42 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - 'master'
+
+  repository_dispatch:
+    types: docs
+
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  Build-and-Deploy-Docs:
+    name: 'Build and push docs'
+
+    runs-on: ubuntu-20.04
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '1'
+
+      - name: Build docs
+        run: |
+          make documentation
+
+      - name: Deploy docs
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: docs/build

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,9 @@ endif
 pangraph/bin/pangraph: compile.jl trace.jl $(srcs) $(testdatum) $(jc)
 	$(jc) $(jflags) $<
 
-documentation:
-	cd docs && julia --project=./.. make.jl
+documentation: environment
+	$(jc) $(jflags) -e 'import Pkg; Pkg.add(name="Documenter");'
+	$(jc) $(jflags) docs/make.jl
 
 release:
 	tar czf pangraph.tar.gz pangraph

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -3,6 +3,11 @@
 julia_version = "1.7.2"
 manifest_format = "2.0"
 
+[[deps.ANSIColoredPrinters]]
+git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
+uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
+version = "0.0.1"
+
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 
@@ -36,9 +41,9 @@ uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 
 [[deps.Conda]]
 deps = ["Downloads", "JSON", "VersionParsing"]
-git-tree-sha1 = "6cdc8832ba11c7695f494c9d9a1c31e90959ce0f"
+git-tree-sha1 = "6e47d11ea2776bc5627421d59cdcc1296c058071"
 uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
-version = "1.6.0"
+version = "1.7.0"
 
 [[deps.DataAPI]]
 git-tree-sha1 = "cc70b17275652eb47bc9e5f81635981f13cea5c8"
@@ -75,6 +80,12 @@ git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.8.6"
 
+[[deps.Documenter]]
+deps = ["ANSIColoredPrinters", "Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
+git-tree-sha1 = "6030186b00a38e9d0434518627426570aac2ef95"
+uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+version = "0.27.23"
+
 [[deps.Downloads]]
 deps = ["ArgTools", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
@@ -96,6 +107,12 @@ deps = ["Libdl"]
 git-tree-sha1 = "039be665faf0b8ae36e089cd694233f5dee3f7d6"
 uuid = "92fee26a-97fe-5a0c-ad85-20a5f3185b63"
 version = "0.5.1"
+
+[[deps.IOCapture]]
+deps = ["Logging", "Random"]
+git-tree-sha1 = "f7be53659ab06ddc986428d3a9dcc95f6fa6705a"
+uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+version = "0.2.2"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,10 @@ authors = ["Nicholas Noll <nbnoll@eml.cc>"]
 version = "0.5.0"
 
 [deps]
+Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 GZip = "92fee26a-97fe-5a0c-ad85-20a5f3185b63"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/docs/dev/building-documentation.md
+++ b/docs/dev/building-documentation.md
@@ -2,7 +2,21 @@
 
 The documentation is hosted on <https://neherlab.github.io/pangraph/>.
 
-To build and release a new version of the documentation:
+### Automated builds
+
+The Continuous integration (CI) will trigger a build and deployment of the docs website to GitHub Pages on every commit to `master` branch (a direct push or a merge of a pull request). You can track the build process on GitHub Actions:
+
+https://github.com/neherlab/pangraph/actions
+
+The docs CI is configured in
+
+```bash
+.github/workflows/docs.yml
+```
+
+### Build manually
+
+To build and release a new version of the documentation manually:
 
 1. run `make documentation`. This will create the directory `docs/build`
 2. switch to the `gh-pages` branch of the repository


### PR DESCRIPTION
This adds a CI workflow which builds and deploys the documentation website on every change to `master` branch. No manual action is required anymore.
