### PR TITLE
chore(ci): deploy docs from git tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,8 @@ name: Docs
 
 on:
   push:
-    branches:
-      - 'master'
+    tags:
+      - '*'
 
   repository_dispatch:
     types: docs

--- a/docs/src/dev/building-documentation.md
+++ b/docs/src/dev/building-documentation.md
@@ -4,7 +4,7 @@ The documentation is hosted on <https://neherlab.github.io/pangraph/>.
 
 ### Automated documentation releases
 
-The Continuous integration (CI) will trigger a build and deployment of the docs website to GitHub Pages on every commit to `master` branch (a direct push or a merge of a pull request). You can track the build process on GitHub Actions:
+The Continuous integration (CI) will trigger a build and deployment of the docs website to GitHub Pages on every git tag (along with the main build). You can track the build process on GitHub Actions:
 
 https://github.com/neherlab/pangraph/actions
 


### PR DESCRIPTION
Instead of deploying on pushes to `master`, here I restrict docs deployment to git tags only. This will ensure that the docs website is in-sync with the releases.

In case this is too conservative, deployments can still be triggered manually as needed, using `repository_dispatch`  (g.g. from GitHub CLI) and `workflow_dispatch` mechanisms (The "Run workflow" button on [Github Actions page](https://github.com/neherlab/pangraph/actions/workflows/docs.yml))