### PR TITLE
chore(ci): ensure branch builds are not cancelled by tag builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref_type }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Currently build triggered by a push to master is cancelled by the followup git tag on the same commit, due to `github.ref` being the same.

But we want `master` branch to deploy to `:master` docker tag, and git tags to be deployed to `:lastest`, so we need both.

To solve this, here I add  `github.ref_type` (`tag` or `branch`) to the `concurrency.group`, such that tag- and branch-triggered builds don't cancel each other.