### PR TITLE
fix: mmseqs paf parsing and added tests

### DIFF
--- a/packages/pangraph/src/align/alignment.rs
+++ b/packages/pangraph/src/align/alignment.rs
@@ -3,7 +3,7 @@ use noodles::sam::record::Cigar;
 use serde::{Deserialize, Serialize};
 
 /// Hit is one side of a pairwise alignment between homologous sequences.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct Hit {
   pub name: String,
   pub length: usize,
@@ -13,7 +13,7 @@ pub struct Hit {
 }
 
 /// Alignment is a pairwise homologous alignment between two sequences.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Alignment {
   pub qry: Hit,
   pub reff: Hit,

--- a/packages/pangraph/src/pangraph/pangraph.rs
+++ b/packages/pangraph/src/pangraph/pangraph.rs
@@ -38,17 +38,11 @@ impl Pangraph {
     Ok(tree_str)
   }
 
-  pub fn sequences(&self) {
-    
-  }
-  
-  pub fn names(&self) {
-    
-  }
-  
-  pub fn sequence_map(&self) {
-    
-  }
+  pub fn sequences(&self) {}
+
+  pub fn names(&self) {}
+
+  pub fn sequence_map(&self) {}
 }
 
 impl FromStr for Pangraph {
@@ -59,7 +53,7 @@ impl FromStr for Pangraph {
   }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, SmartDefault)]
+#[derive(Clone, Serialize, Deserialize, Debug, SmartDefault, PartialEq)]
 pub enum Strand {
   #[default]
   Forward,


### PR DESCRIPTION
I created some dummy sequences and used mmseqs to align them, and used the results to add tests to the mmseqs paf parsing.

I used the command:
```sh
mmseqs easy-search \
  qry.fasta \
  ref.fasta \
  results_mmseqs_rev.paf \
  tmp \
  --threads 1 \
  --max-seq-len 10000 \
  -a \
  --search-type 3 \
  --format-output "query,qlen,qstart,qend,empty,target,tlen,tstart,tend,nident,alnlen,bits,cigar,fident,raw"
```

A somewhat unexpected behavior is that it seems that the target sequence start and end are always inverted in the output file (mmseqs2 version 15.6f452). I think this should be investigated more but in the meantime I added the tests using the raw output from mmseqs as test input and artificially inverting the ref-sequence start/end when inverted. This is irrespective of whether the match is on the forward/reverse strand.