### PR TITLE
fix: apply deletions without causing frame shifts

### DIFF
--- a/packages/pangraph/src/pangraph/edits.rs
+++ b/packages/pangraph/src/pangraph/edits.rs
@@ -69,7 +69,10 @@ impl Edits {
     }
 
     for del in &self.dels {
-      qry.drain(del.range());
+      // Replace deleted nucs with character `-`, to avoid frame shift
+      for pos in del.range() {
+        qry[pos] = '-';
+      }
     }
 
     for ins in &self.inss {
@@ -77,6 +80,9 @@ impl Edits {
       let seq = ins.seq.chars().collect_vec();
       insert_at_inplace(&mut qry, ins.pos, &seq);
     }
+
+    // Strip gaps introduced when applying deletions
+    qry.retain(|c| c != &'-');
 
     let qry = String::from_iter(&qry);
     Ok(qry)


### PR DESCRIPTION
Instead of stripping deleted ranges wight away, I first replace these ranges with character `-`. At the end of the function I strip all characters `-`.

This is to ensure that no reading frame shifts introduced and that all deletions and insertions are applied to correct positions.