### PR TITLE
fix: avoid frame shifts when applying insertions

### DIFF
--- a/packages/pangraph/src/pangraph/edits.rs
+++ b/packages/pangraph/src/pangraph/edits.rs
@@ -36,7 +36,7 @@ impl Del {
   }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Ins {
   pub pos: usize,
   pub seq: String,
@@ -72,7 +72,7 @@ impl Edits {
       qry.drain(del.range());
     }
 
-    for ins in &self.inss {
+    for ins in self.inss.iter().sorted().rev() {
       // TODO: avoid copy
       let seq = ins.seq.chars().collect_vec();
       insert_at_inplace(&mut qry, ins.pos, &seq);


### PR DESCRIPTION
Here I sort insertions in reverse order according to their positions. This means that the sequence grows starting from back (rightmost insertions are applied first).

This prevents frame shifts, compared to when applying left-to-right or, worse, in some unspecified order. But the correctness of this needs to be double-checked.

The `Ord` trait sorts instances of` Ins` by `pos` first and then by `seq` in case of equality. It is important to preserve order of fields in the struct. Otherwise, we may implement `Ord` trait explicitly.