### PR TITLE
nextclade alignment tests

### DIFF
--- a/packages/pangraph/src/align/map_variations.rs
+++ b/packages/pangraph/src/align/map_variations.rs
@@ -52,8 +52,6 @@ mod tests {
     // ref = "ACT---TTGCGTCTGATAGCTTAGCGGATATTGACTGTA"
     // qry = "ACTAGATTGAGTCTGATAGCTTAGCGGATATT----GTA"
     // sub =           x
-    // ins =     xxx
-    // del =                                  xxxx
 
     let r = "ACTTTGCGTCTGATAGCTTAGCGGATATTTACTGTA";
     let q = "ACTAGATTGAGTCTGATAGCTTAGCGGATATTGTA";
@@ -93,6 +91,35 @@ mod tests {
       subs: vec![Sub::new(10, 'A')],
       dels: vec![Del::new(0, 3), Del::new(36, 4)],
       inss: vec![Ins::new(21, "GGT")],
+    };
+
+    // test that our example is correct
+    assert_eq!(q, expected.apply(r).unwrap());
+
+    // test that the aligner reconstructs the variations correctly
+    assert_eq!(expected, actual);
+
+    // test that the reconstructed variations are correct
+    assert_eq!(q, actual.apply(r).unwrap());
+  }
+
+  #[rstest]
+  fn test_map_variations_initial_final_insertions() {
+    //           0         1         2            3
+    //           012345678901234567890   1234567890123456789
+    // ref = ----ACACTGATTTCGTCCCTTAGG---TACTCTACACTGTAGCCTA-------
+    // qry = CCTGACACTGATTTAGTCC--TAGGGGTTACTCTACACCGTAGCCTAGCCGCCG
+    // sub =               x                       x
+
+    let r = "ACACTGATTTCGTCCCTTAGGTACTCTACACTGTAGCCTA";
+    let q = "CCTGACACTGATTTAGTCCTAGGGGTTACTCTACACCGTAGCCTAGCCGCCG";
+
+    let actual = map_variations(r, q).unwrap();
+
+    let expected = Edits {
+      subs: vec![Sub::new(10, 'A'), Sub::new(31, 'C')],
+      dels: vec![Del::new(15, 2)],
+      inss: vec![Ins::new(0, "CCTG"), Ins::new(21, "GGT"), Ins::new(40, "GCCGCCG")],
     };
 
     // test that our example is correct

--- a/packages/pangraph/src/align/map_variations.rs
+++ b/packages/pangraph/src/align/map_variations.rs
@@ -131,4 +131,32 @@ mod tests {
     // test that the reconstructed variations are correct
     assert_eq!(q, actual.apply(r).unwrap());
   }
+
+  #[rstest]
+  fn test_map_variations_overlapping_indels() {
+    //       0         1         2                      3         4         5
+    //       012345678901234567890             123456789012345678901234567890
+    // ref = CGCCCTACTACAAGAGGGAAC-------------TTTTTTTTTAAGTATAGCCACAATAGCTGG
+    // qry = CGCCCTACTACAAGAGGGAACGGGGGGGGGGGGG---------AAGTATAGCCACAATAGCTGG
+
+    let r = "CGCCCTACTACAAGAGGGAACTTTTTTTTTAAGTATAGCCACAATAGCTGG";
+    let q = "CGCCCTACTACAAGAGGGAACGGGGGGGGGGGGGAAGTATAGCCACAATAGCTGG";
+
+    let actual = map_variations(r, q).unwrap();
+
+    let expected = Edits {
+      subs: vec![],
+      dels: vec![Del::new(21, 9)],
+      inss: vec![Ins::new(21, "GGGGGGGGGGGGG")],
+    };
+
+    // test that our example is correct
+    assert_eq!(q, expected.apply(r).unwrap());
+
+    // test that the aligner reconstructs the variations correctly
+    assert_eq!(expected, actual);
+
+    // test that the reconstructed variations are correct
+    assert_eq!(q, actual.apply(r).unwrap());
+  }
 }

--- a/packages/pangraph/src/align/map_variations.rs
+++ b/packages/pangraph/src/align/map_variations.rs
@@ -75,4 +75,33 @@ mod tests {
     // test that the reconstructed variations are correct
     assert_eq!(q, actual.apply(r).unwrap());
   }
+
+  #[rstest]
+  fn test_map_variations_initial_final_deletions() {
+    //       0         1         2         3
+    //       012345678901234567890   1234567890123456789
+    // ref = ACACTGATTTCGTCCCTTAGG---TACTCTACACTGTAGCCTA
+    // qry = ---CTGATTTAGTCCCTTAGGGGTTACTCTACACTGTAG----
+    // sub =           x
+
+    let r = "ACACTGATTTCGTCCCTTAGGTACTCTACACTGTAGCCTA";
+    let q = "CTGATTTAGTCCCTTAGGGGTTACTCTACACTGTAG";
+
+    let actual = map_variations(r, q).unwrap();
+
+    let expected = Edits {
+      subs: vec![Sub::new(10, 'A')],
+      dels: vec![Del::new(0, 3), Del::new(36, 4)],
+      inss: vec![Ins::new(21, "GGT")],
+    };
+
+    // test that our example is correct
+    assert_eq!(q, expected.apply(r).unwrap());
+
+    // test that the aligner reconstructs the variations correctly
+    assert_eq!(expected, actual);
+
+    // test that the reconstructed variations are correct
+    assert_eq!(q, actual.apply(r).unwrap());
+  }
 }


### PR DESCRIPTION
- added processing of nextclade alignment output to consider lateral unaligned overhangs of the reference as query deletions.
- added alignment tests for lateral in/dels and overlapping indels. In the latter case there is often ambiguity in where the indel should be placed, but I think this is acceptable at this stage.