### PR TITLE
fix: merge block test

### DIFF
--- a/notebooks/block_operations/block_operations.ipynb
+++ b/notebooks/block_operations/block_operations.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -167,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,14 +235,14 @@
     "```txt\n",
     "            0         1         2         3         \n",
     "            0123456789012345678901234567890123456789\n",
-    "consensus = GACTAAACCTGTCCGCTGAAACTGAGCGGGGTACTGCAGC\n",
+    "consensus = GACTAAACCTGTCCGCTGAAACTGATCGGGGTACTGCAGC\n",
     "\n",
     "                                         GAT\n",
-    "    seq_0 = GACTAAA---GTCCGCTGAAACTGAGCGGGGTATTGCAGC\n",
+    "    seq_0 = GACTAAA---GTCCGCTGAAACTGATCGGGGTATTGCAGC\n",
     "                           ACA\n",
-    "    seq_1 = GACTAAACCTGTCCGCTGAAATTGAGCGGG---CTGCAGC\n",
+    "    seq_1 = GACTAAACCTGTCCGCTGAAATTGATCGGG---CTGCAGC\n",
     "                          AAT\n",
-    "    seq_2 = ---TAAACCTGTCCGCTGAAACTGAGCGGGGTACTGCAGC\n",
+    "    seq_2 = ---TAAACCTGTCCGCTGAAACTGATCGGGGTACTGCAGC\n",
     "```\n",
     "\n",
     "**Block B**\n",
@@ -260,7 +260,7 @@
     "The alignment of the two consensus sequences:\n",
     "```txt\n",
     "            x\n",
-    "cons_A = GACTAAACCTGTCCGCTGAAACTGAGCGGGGTACTGCAGC\n",
+    "cons_A = GACTAAACCTGTCCGCTGAAACTGATCGGGGTACTGCAGC\n",
     "cons_B = GACCAAACCTGTCCGCTGAAACTG--CGGGGTACTGCAGC\n",
     "```\n",
     "\n",
@@ -269,28 +269,28 @@
     "```txt\n",
     "            0         1         2         3         \n",
     "            0123456789012345678901234567890123456789\n",
-    "consensus = GACTAAACCTGTCCGCTGAAACTGAGCGGGGTACTGCAGC\n",
+    "consensus = GACTAAACCTGTCCGCTGAAACTGATCGGGGTACTGCAGC\n",
     "\n",
     "                                         GAT\n",
-    "    seq_0 = GACTAAA---GTCCGCTGAAACTGAGCGGGGTATTGCAGC\n",
+    "    seq_0 = GACTAAA---GTCCGCTGAAACTGATCGGGGTATTGCAGC\n",
     "                           ACA\n",
-    "    seq_1 = GACTAAACCTGTCCGCTGAAATTGAGCGGG---CTGCAGC\n",
+    "    seq_1 = GACTAAACCTGTCCGCTGAAATTGATCGGG---CTGCAGC\n",
     "                          AAT\n",
-    "    seq_2 = ---TAAACCTGTCCGCTGAAACTGAGCGGGGTACTGCAGC\n",
+    "    seq_2 = ---TAAACCTGTCCGCTGAAACTGATCGGGGTACTGCAGC\n",
     "              \n",
-    "    seq_3 = GACCTAACCTGTC---TGAAACT--GCGGGGTACTGCAGC\n",
+    "    seq_3 = GACCTAACCTGTC---TGAAACTG--CGGGGTACTGCAGC\n",
     "                                        AAA\n",
-    "    seq_4 = GACTAAACCTGTCCGCTGAAACT--GCGGGGTACTGCAGC\n",
+    "    seq_4 = GACTAAACCTGTCCGCTGAAACTG--CGGGGTACTGCAGC\n",
     "```\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
-    "cons_A = \"GACTAAACCTGTCCGCTGAAACTGAGCGGGGTACTGCAGC\"\n",
+    "cons_A = \"GACTAAACCTGTCCGCTGAAACTGATCGGGGTACTGCAGC\"\n",
     "aln_A = {\n",
     "    \"seq_0\" : Edits(ins=[Insertion(29, \"GAT\")], dels=[Deletion(7, 3)], subs=[Substitution(33, \"T\")]),\n",
     "    \"seq_1\" : Edits(ins=[Insertion(15, \"ACA\")], dels=[Deletion(30, 3)], subs=[Substitution(21, \"T\")]),\n",
@@ -323,13 +323,13 @@
     "new_block = merge_blocks(block_A, block_B, \"new_block\")\n",
     "\n",
     "\n",
-    "new_cons = \"GACTAAACCTGTCCGCTGAAACTGAGCGGGGTACTGCAGC\"\n",
+    "new_cons = \"GACTAAACCTGTCCGCTGAAACTGATCGGGGTACTGCAGC\"\n",
     "new_aln = {\n",
     "    \"seq_0\" : Edits(ins=[Insertion(29, \"GAT\")], dels=[Deletion(7, 3)], subs=[Substitution(33, \"T\")]),\n",
     "    \"seq_1\" : Edits(ins=[Insertion(15, \"ACA\")], dels=[Deletion(30, 3)], subs=[Substitution(21, \"T\")]),\n",
     "    \"seq_2\" : Edits(ins=[Insertion(14, \"AAT\")], dels=[Deletion(0, 3)], subs=[Substitution(0, \"C\")]),\n",
-    "    \"seq_3\" : Edits(dels=[Deletion(13, 3), Deletion(23, 2)], subs=[Substitution(4, \"T\")]),\n",
-    "    \"seq_4\" : Edits(dels=[Deletion(23,2)], ins=[Insertion(28, \"AAA\")]),\n",
+    "    \"seq_3\" : Edits(dels=[Deletion(13, 3), Deletion(24, 2)], subs=[Substitution(3, \"C\"), Substitution(4, \"C\")]),\n",
+    "    \"seq_4\" : Edits(dels=[Deletion(24,2)], ins=[Insertion(28, \"AAA\")]),\n",
     "    }\n",
     "expected_new_block = Block(\"new_block\", new_cons, new_aln)\n",
     "# new_block == expected_new_block"
@@ -382,7 +382,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -449,7 +449,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.1"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,

--- a/packages/pangraph/src/pangraph/merge_blocks.rs
+++ b/packages/pangraph/src/pangraph/merge_blocks.rs
@@ -29,7 +29,7 @@ mod tests {
 
   #[rstest]
   fn test_merge_blocks_simple_case() -> Result<(), Report> {
-    let cons_A = o!("GACTAAACCTGTCCGCTGAAACTGAGCGGGGTACTGCAGC");
+    let cons_A = o!("GACTAAACCTGTCCGCTGAAACTGATCGGGGTACTGCAGC");
     let aln_A = BTreeMap::from([
       (
         0,
@@ -82,7 +82,7 @@ mod tests {
 
     let new_block = merge_blocks_inplace(&mut block_A, &block_B)?;
 
-    let new_cons = o!("GACTAAACCTGTCCGCTGAAACTGAGCGGGGTACTGCAGC");
+    let new_cons = o!("GACTAAACCTGTCCGCTGAAACTGATCGGGGTACTGCAGC");
     let new_aln = BTreeMap::from([
       (
         0,
@@ -112,15 +112,15 @@ mod tests {
         3,
         Edits {
           inss: vec![],
-          dels: vec![Del::new(13, 3), Del::new(23, 2)],
-          subs: vec![Sub::new(4, 'T')],
+          dels: vec![Del::new(13, 3), Del::new(24, 2)],
+          subs: vec![Sub::new(3, 'C'), Sub::new(4, 'T')],
         },
       ),
       (
         4,
         Edits {
           inss: vec![Ins::new(28, "AAA")],
-          dels: vec![Del::new(23, 2)],
+          dels: vec![Del::new(24, 2)],
           subs: vec![],
         },
       ),


### PR DESCRIPTION
fixed block merging test. This was due to an ambiguity in alignment (now removed) plus a missed mutation when I designed the test.
