### PR TITLE
minimap2 fix

### DIFF
--- a/packages/pangraph/src/align/minimap2/align_with_minimap2.rs
+++ b/packages/pangraph/src/align/minimap2/align_with_minimap2.rs
@@ -45,8 +45,14 @@ pub fn align_with_minimap2(
     $input_path
     $[kmer_size]
     $[preset]
-    > $output_path
     2> /dev/null
+    |
+    sed
+    "s/\tzd:i:[0-9]*//g"
+    |
+    sed
+    "s/\ts2:i:[0-9]*//g"
+    > $output_path
   ).wrap_err("When trying to align sequences using minimap2")?;
 
   let mut paf_str = String::new();

--- a/packages/pangraph/src/align/minimap2/align_with_minimap2.rs
+++ b/packages/pangraph/src/align/minimap2/align_with_minimap2.rs
@@ -40,6 +40,7 @@ pub fn align_with_minimap2(
   run_cmd!(
     minimap2
     -c
+    -X
     $input_path
     $input_path
     $[kmer_size]

--- a/packages/pangraph/src/align/minimap2/minimap2_paf.rs
+++ b/packages/pangraph/src/align/minimap2/minimap2_paf.rs
@@ -29,7 +29,7 @@ pub struct MinimapPafTsvRecord {
   /* 17 */ tp: String,
   /* 18 */ cm: String,
   /* 19 */ s1: String,
-  /* 20 */ s2: String,
+  // /* 20 */ s2: String,
   /* 21 */ de: String,
   /* 22 */ rl: String,
   /* 23 */ cg: String,

--- a/packages/pangraph/src/pangraph/graph_merging.rs
+++ b/packages/pangraph/src/pangraph/graph_merging.rs
@@ -34,7 +34,10 @@ pub fn merge_graphs(
   // is possible.
   let mut i = 0;
   loop {
-    debug!("Self-merge iteration {i}");
+    // print keys of left/right graph paths
+    let left_keys = left_graph.paths.keys().map(|k| k.to_string()).join(", ");
+    let right_keys = right_graph.paths.keys().map(|k| k.to_string()).join(", ");
+    debug!("Self-merge iteration {i} of left/right graph {left_keys} <---> {right_keys}");
 
     let (graph_new, has_changed) =
       self_merge(graph, args).wrap_err_with(|| format!("During self-merge iteration {i}"))?;
@@ -42,9 +45,9 @@ pub fn merge_graphs(
 
     // stop when no more mergers are possible
     if !has_changed {
+      debug!("Graph merge {left_keys} <---> {right_keys} complete.");
       break Ok(graph);
     }
-
     i += 1;
   }
 }


### PR DESCRIPTION
the rust version is compiling! :confetti_ball: 
Now starting to polish away the errors. The first error I encountered was related to minimap2.

When looking for homologous regions we're  aligning a fasta file against itself. The best mapping would always be of one segment agains itself, but these are not interesting. They can be excluded with the `-X` flag, [added in the first commit here](https://github.com/neherlab/pangraph/blob/9150db3b685abc8ef60660afbba545edd60b22b7/packages/pangraph/src/align/minimap2/align_with_minimap2.rs#L43)

The second problem is a bit more complex: the output of minimap is a `.paf` file with each line representing a different alignment between two blocks. Currently we assume these lines to be always composed of 22 tab-separated columns. However sometimes they have some extra field (e.g. `zd:i:1`) or are missing some other (e.g. `s2:i:2`). The real solution would be to properly parse the paf file following the specifications ([see output section here](https://lh3.github.io/minimap2/minimap2.html)). This file always has 12 positional columns, and then it has some extra optional fields, most of which we do not actually use.

Currently I implemented an [ugly patch](https://github.com/neherlab/pangraph/blob/9150db3b685abc8ef60660afbba545edd60b22b7/packages/pangraph/src/align/minimap2/align_with_minimap2.rs#L49-L54) in which I remove with `sed` some of the optional columns if present, and I also [removed an entry from the expected list of columns](https://github.com/neherlab/pangraph/blob/9150db3b685abc8ef60660afbba545edd60b22b7/packages/pangraph/src/align/minimap2/minimap2_paf.rs#L32).