### PR TITLE
fix missing block id error

### DIFF
--- a/packages/pangraph/src/bin/minimap2_example.rs
+++ b/packages/pangraph/src/bin/minimap2_example.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), Report> {
     .into_iter()
     .map(|r| r.seq)
     .enumerate()
-    .map(|(i, seq)| PangraphBlock::new(Some(BlockId(i)), seq.replace(['\n', ' '], ""), btreemap! {}))
+    .map(|(i, seq)| PangraphBlock::new(BlockId(i), seq.replace(['\n', ' '], ""), btreemap! {}))
     .map(|block| (block.id(), block))
     .collect();
 

--- a/packages/pangraph/src/bin/mmseqs_example.rs
+++ b/packages/pangraph/src/bin/mmseqs_example.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), Report> {
     .into_iter()
     .map(|r| r.seq)
     .enumerate()
-    .map(|(i, seq)| PangraphBlock::new(Some(BlockId(i)), seq.replace(['\n', ' '], ""), btreemap! {}))
+    .map(|(i, seq)| PangraphBlock::new(BlockId(i), seq.replace(['\n', ' '], ""), btreemap! {}))
     .map(|block| (block.id(), block))
     .collect();
 

--- a/packages/pangraph/src/pangraph/graph_merging.rs
+++ b/packages/pangraph/src/pangraph/graph_merging.rs
@@ -57,9 +57,21 @@ pub fn merge_graphs(
 pub fn graph_join(left_graph: &Pangraph, right_graph: &Pangraph) -> Pangraph {
   // simply join the two sets of blocks and paths
   Pangraph {
-    blocks: map_merge(&left_graph.blocks, &right_graph.blocks, ConflictResolution::Left),
-    paths: map_merge(&left_graph.paths, &right_graph.paths, ConflictResolution::Left),
-    nodes: map_merge(&left_graph.nodes, &right_graph.nodes, ConflictResolution::Left),
+    blocks: map_merge(
+      &left_graph.blocks,
+      &right_graph.blocks,
+      ConflictResolution::Custom(|(kl, vl), (kr, vr)| panic!("Conflicting key: '{kl}'")),
+    ),
+    paths: map_merge(
+      &left_graph.paths,
+      &right_graph.paths,
+      ConflictResolution::Custom(|(kl, vl), (kr, vr)| panic!("Conflicting key: '{kl}'")),
+    ),
+    nodes: map_merge(
+      &left_graph.nodes,
+      &right_graph.nodes,
+      ConflictResolution::Custom(|(kl, vl), (kr, vr)| panic!("Conflicting key: '{kl}'")),
+    ),
   }
 }
 
@@ -125,7 +137,11 @@ pub fn self_merge(graph: Pangraph, args: &PangraphBuildArgs) -> Result<(Pangraph
     .collect::<BTreeMap<_, _>>();
 
   // add the new blocks to the graph
-  graph.blocks = map_merge(&graph.blocks, &merged_blocks, ConflictResolution::Right);
+  graph.blocks = map_merge(
+    &graph.blocks,
+    &merged_blocks,
+    ConflictResolution::Custom(|(k1, _), (k2, _)| panic!("Conflicting key '{k1}'")),
+  );
 
   // we might need this step for some final updates and consistency checks.
   // TODO: here we could also take care of transitive edges, which is useful

--- a/packages/pangraph/src/pangraph/pangraph.rs
+++ b/packages/pangraph/src/pangraph/pangraph.rs
@@ -77,6 +77,9 @@ impl Pangraph {
 
       let old_idx = path.nodes.iter().position(|node_id| node_id == old_node_id).unwrap();
 
+      // only one such nodes
+      debug_assert!(path.nodes.iter().filter(|node_id| *node_id == old_node_id).count() == 1);
+
       path.nodes.remove(old_idx);
 
       let new_ids: Vec<NodeId> = new_nodes.iter().map(|n| n.id()).collect();

--- a/packages/pangraph/src/pangraph/pangraph.rs
+++ b/packages/pangraph/src/pangraph/pangraph.rs
@@ -25,7 +25,8 @@ impl Pangraph {
   pub fn singleton(fasta: FastaRecord, strand: Strand, circular: bool) -> Self {
     let tot_len = fasta.seq.len();
     let node_id = NodeId(fasta.index);
-    let block = PangraphBlock::from_consensus(fasta.seq, node_id);
+    let block_id = BlockId(fasta.index);
+    let block = PangraphBlock::from_consensus(fasta.seq, block_id, node_id);
     let path_id = PathId(fasta.index);
     let node = PangraphNode::new(Some(node_id), block.id(), path_id, strand, (0, 0));
     let path = PangraphPath::new(Some(path_id), [node.id()], tot_len, circular, Some(fasta.seq_name));
@@ -142,11 +143,11 @@ mod tests {
     };
 
     let blocks = btreemap! {
-      BlockId(1) => PangraphBlock::new(Some(BlockId(1)), "1",
+      BlockId(1) => PangraphBlock::new(BlockId(1), "1",
         btreemap!{ NodeId(1) => Edit::empty(), NodeId(2) => Edit::empty() }),
-      BlockId(2) => PangraphBlock::new(Some(BlockId(2)), "2",
+      BlockId(2) => PangraphBlock::new(BlockId(2), "2",
         btreemap!{ NodeId(3) => Edit::empty(), NodeId(4) => Edit::empty(), NodeId(5) => Edit::empty() }),
-      BlockId(3) => PangraphBlock::new(Some(BlockId(3)), "3",
+      BlockId(3) => PangraphBlock::new(BlockId(3), "3",
         btreemap!{ NodeId(6) => Edit::empty(), NodeId(7) => Edit::empty(), NodeId(8) => Edit::empty(), }),
     };
 
@@ -172,8 +173,8 @@ mod tests {
     };
 
     let new_blocks = btreemap! {
-      BlockId(4) => PangraphBlock::new(Some(BlockId(4)), "4", btreemap!{}),
-      BlockId(5) => PangraphBlock::new(Some(BlockId(5)), "5", btreemap!{}),
+      BlockId(4) => PangraphBlock::new(BlockId(4), "4", btreemap!{}),
+      BlockId(5) => PangraphBlock::new(BlockId(5), "5", btreemap!{}),
     };
 
     let update = GraphUpdate {

--- a/packages/pangraph/src/pangraph/pangraph_block.rs
+++ b/packages/pangraph/src/pangraph/pangraph_block.rs
@@ -45,10 +45,6 @@ impl PangraphBlock {
     }
   }
 
-  pub fn refresh_id(&mut self) {
-    self.id = id((&self.consensus, &self.alignments));
-  }
-
   pub fn depth(&self) -> usize {
     self.alignments.len()
   }

--- a/packages/pangraph/src/pangraph/pangraph_block.rs
+++ b/packages/pangraph/src/pangraph/pangraph_block.rs
@@ -31,13 +31,13 @@ pub struct PangraphBlock {
 }
 
 impl PangraphBlock {
-  pub fn from_consensus(consensus: impl Into<String>, nid: NodeId) -> Self {
-    PangraphBlock::new(None, consensus, btreemap! {nid => Edit::empty()})
+  pub fn from_consensus(consensus: impl Into<String>, block_id: BlockId, nid: NodeId) -> Self {
+    PangraphBlock::new(block_id, consensus, btreemap! {nid => Edit::empty()})
   }
 
-  pub fn new(block_id: Option<BlockId>, consensus: impl Into<String>, alignments: BTreeMap<NodeId, Edit>) -> Self {
+  pub fn new(block_id: BlockId, consensus: impl Into<String>, alignments: BTreeMap<NodeId, Edit>) -> Self {
     let consensus = consensus.into();
-    let id = block_id.unwrap_or_else(|| id((&consensus, &alignments)));
+    let id = block_id;
     Self {
       id,
       consensus,

--- a/packages/pangraph/src/pangraph/reweave.rs
+++ b/packages/pangraph/src/pangraph/reweave.rs
@@ -50,7 +50,6 @@ impl MergePromise {
       .for_each(|(node_id, edits)| {
         self.anchor_block.alignment_insert(node_id, edits);
       });
-    self.anchor_block.refresh_id();
     Ok(self.anchor_block.clone())
   }
 }
@@ -78,6 +77,7 @@ impl ToMerge {
 
 fn assign_new_block_ids(mergers: &mut [Alignment]) {
   for a in mergers.iter_mut() {
+    debug_assert!(a.new_block_id.is_none());
     a.new_block_id = Some(BlockId(
       // FIXME: looks like this is trying to calculate its own hash id? It should probably not be done in random places like this.
       id((&a.qry.name, &a.qry.interval, &a.reff.name, &a.reff.interval)),

--- a/packages/pangraph/src/pangraph/reweave.rs
+++ b/packages/pangraph/src/pangraph/reweave.rs
@@ -353,12 +353,12 @@ mod tests {
   #[rustfmt::skip]
   #[test]
   fn test_group_promises() -> Result<(), Report>  {
-    let b1_anchor = PangraphBlock::new(Some(BlockId(1)), "A", btreemap! {} /* {1: None, 2: None, 3: None} */);
-    let b1_append = PangraphBlock::new(Some(BlockId(1)), "B", btreemap! {} /* {4: None, 5: None} */);
-    let b2_anchor = PangraphBlock::new(Some(BlockId(2)), "C", btreemap! {} /* {6: None, 7: None, 8: None} */);
-    let b2_append = PangraphBlock::new(Some(BlockId(2)), "D", btreemap! {} /* {7: None, 8: None} */);
-    let b3_anchor = PangraphBlock::new(Some(BlockId(3)), "E", btreemap! {} /* {11: None, 12: None} */);
-    let b3_append = PangraphBlock::new(Some(BlockId(3)), "F", btreemap! {} /* {13: None} */);
+    let b1_anchor = PangraphBlock::new(BlockId(1), "A", btreemap! {} /* {1: None, 2: None, 3: None} */);
+    let b1_append = PangraphBlock::new(BlockId(1), "B", btreemap! {} /* {4: None, 5: None} */);
+    let b2_anchor = PangraphBlock::new(BlockId(2), "C", btreemap! {} /* {6: None, 7: None, 8: None} */);
+    let b2_append = PangraphBlock::new(BlockId(2), "D", btreemap! {} /* {7: None, 8: None} */);
+    let b3_anchor = PangraphBlock::new(BlockId(3), "E", btreemap! {} /* {11: None, 12: None} */);
+    let b3_append = PangraphBlock::new(BlockId(3), "F", btreemap! {} /* {13: None} */);
 
     let h = &[
       ToMerge::new(b1_anchor.clone(), true, Forward),
@@ -414,10 +414,10 @@ mod tests {
       nids.iter().map(|nid| (NodeId(*nid), Edit::empty())).collect()
     }
 
-    let b1 = PangraphBlock::new(Some(BlockId(1)), "A", e(&[1, 2, 3]));
-    let b2 = PangraphBlock::new(Some(BlockId(2)), "B", e(&[4, 5]));
-    let b3 = PangraphBlock::new(Some(BlockId(3)), "C", e(&[6]));
-    let b4 = PangraphBlock::new(Some(BlockId(4)), "D", e(&[7, 8, 9, 10]));
+    let b1 = PangraphBlock::new(BlockId(1), "A", e(&[1, 2, 3]));
+    let b2 = PangraphBlock::new(BlockId(2), "B", e(&[4, 5]));
+    let b3 = PangraphBlock::new(BlockId(3), "C", e(&[6]));
+    let b4 = PangraphBlock::new(BlockId(4), "D", e(&[7, 8, 9, 10]));
 
     let pangraph = Pangraph {
       blocks: btreemap! {
@@ -509,7 +509,7 @@ mod tests {
       let n3 = PangraphNode::new(Some(nid3), bid, PathId(300), Reverse, (180, 110));
 
       let b1 = PangraphBlock::new(
-        Some(bid),
+        bid,
         consensus,
         btreemap! {
           nid1 => Edit::empty(),
@@ -702,7 +702,7 @@ mod tests {
 
       let b = |bid: usize, nids: &[usize]| -> PangraphBlock {
         PangraphBlock::new(
-          Some(BlockId(bid)),
+          BlockId(bid),
           &bseq[&BlockId(bid)],
           nids
             .iter()

--- a/packages/pangraph/src/pangraph/slice.rs
+++ b/packages/pangraph/src/pangraph/slice.rs
@@ -137,7 +137,8 @@ pub fn block_slice(
     node_updates.insert(*old_node_id, new_node.clone());
 
     let new_edits = slice_edits(i, edits, block_L);
-    new_alignment.insert(new_node.id(), new_edits);
+    let ovw = new_alignment.insert(new_node.id(), new_edits);
+    debug_assert!(ovw.is_none()); // new node id is not already in new_alignment
   }
 
   let new_block = PangraphBlock::new(Some(i.new_block_id), new_consensus, new_alignment);

--- a/packages/pangraph/src/pangraph/slice.rs
+++ b/packages/pangraph/src/pangraph/slice.rs
@@ -141,7 +141,7 @@ pub fn block_slice(
     debug_assert!(ovw.is_none()); // new node id is not already in new_alignment
   }
 
-  let new_block = PangraphBlock::new(Some(i.new_block_id), new_consensus, new_alignment);
+  let new_block = PangraphBlock::new(i.new_block_id, new_consensus, new_alignment);
 
   (new_block, node_updates)
 }
@@ -459,7 +459,7 @@ mod tests {
     let p3 = PangraphPath::new(Some(PathId(3)), /*"p3"*/ [NodeId(3), NodeId(6)], 100, true, None);
 
     let b1 = PangraphBlock::new(
-      Some(bid),
+      bid,
       seq,
       btreemap! {
         NodeId(1) => ed1,


### PR DESCRIPTION
The error was due to the way block id was recalculated. I think it was introduced at some point in our discussions of how to assign ids to blocks.
I removed the possibility of automatically assign an id to a block, now block id must be passed explicitly at block construction.