### PR TITLE
improve block merging and fix edge-cases bugs

### DIFF
--- a/data/sc2.fa
+++ b/data/sc2.fa
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0186ac417e8050bdc31fa66c58170fb61fc1bc3da17cf388b114e0f254f1c31c
-size 5036223
+oid sha256:b02dfbfbd7f938e737eddfe0ccee13f8d4623c93f01eff82eeca0fddc8293bac
+size 5036224

--- a/data/sc2.fa
+++ b/data/sc2.fa
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:07d3a0c3885f56711520a9c9a5a5abb813767e9772512747bf0b37cfa430d2c7
-size 5036222
+oid sha256:0186ac417e8050bdc31fa66c58170fb61fc1bc3da17cf388b114e0f254f1c31c
+size 5036223

--- a/packages/pangraph/src/align/map_variations.rs
+++ b/packages/pangraph/src/align/map_variations.rs
@@ -11,32 +11,30 @@ pub fn map_variations(ref_seq: impl AsRef<str>, qry_seq: impl AsRef<str>) -> Res
     ..NextalignParams::default()
   };
 
-  Ok({
-    let AlignWithNextcladeOutput {
-      substitutions,
-      deletions,
-      insertions,
-      ..
-    } = align_with_nextclade(ref_seq, qry_seq, &params)?;
+  let AlignWithNextcladeOutput {
+    substitutions,
+    deletions,
+    insertions,
+    ..
+  } = align_with_nextclade(ref_seq, qry_seq, &params)?;
 
-    let subs = substitutions
-      .iter()
-      .map(|s| Sub::new(s.pos.inner as usize, from_nuc(s.qry_nuc)))
-      .collect_vec();
+  let subs = substitutions
+    .iter()
+    .map(|s| Sub::new(s.pos.inner as usize, from_nuc(s.qry_nuc)))
+    .collect_vec();
 
-    let dels = deletions
-      .iter()
-      .map(|d| Del::new(d.range().begin.inner as usize, d.range().len()))
-      .collect_vec();
+  let dels = deletions
+    .iter()
+    .map(|d| Del::new(d.range().begin.inner as usize, d.range().len()))
+    .collect_vec();
 
-    // pangraph convention: location of insertion is the position *after* the insertion -> increment pos by 1
-    let inss = insertions
-      .iter()
-      .map(|s| Ins::new((s.pos + 1) as usize, from_nuc_seq(&s.ins)))
-      .collect_vec();
+  // pangraph convention: location of insertion is the position *after* the insertion -> increment pos by 1
+  let inss = insertions
+    .iter()
+    .map(|s| Ins::new((s.pos + 1) as usize, from_nuc_seq(&s.ins)))
+    .collect_vec();
 
-    Edit { subs, dels, inss }
-  })
+  Ok(Edit { subs, dels, inss })
 }
 
 #[cfg(test)]

--- a/packages/pangraph/src/align/map_variations.rs
+++ b/packages/pangraph/src/align/map_variations.rs
@@ -8,7 +8,6 @@ use itertools::Itertools;
 pub fn map_variations(ref_seq: impl AsRef<str>, qry_seq: impl AsRef<str>) -> Result<Edit, Report> {
   let params = NextalignParams {
     min_length: 3,
-    min_match_length: 3,
     ..NextalignParams::default()
   };
 

--- a/packages/pangraph/src/align/map_variations.rs
+++ b/packages/pangraph/src/align/map_variations.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 
 pub fn map_variations(ref_seq: impl AsRef<str>, qry_seq: impl AsRef<str>) -> Result<Edit, Report> {
   let params = NextalignParams {
-    min_length: 3,
+    min_length: 1,
     ..NextalignParams::default()
   };
 

--- a/packages/pangraph/src/align/map_variations.rs
+++ b/packages/pangraph/src/align/map_variations.rs
@@ -9,41 +9,35 @@ pub fn map_variations(ref_seq: impl AsRef<str>, qry_seq: impl AsRef<str>) -> Res
   let params = NextalignParams {
     min_length: 3,
     min_match_length: 3,
-    allowed_mismatches: 16,
-    terminal_bandwidth: 100,
-    excess_bandwidth: 18,
-    max_band_area: 1_000_000_000,
     ..NextalignParams::default()
   };
 
-  Ok(
-    align_with_nextclade(ref_seq, qry_seq, &params)?.map_or_else(Edit::default, |aln| {
-      let AlignWithNextcladeOutput {
-        substitutions,
-        deletions,
-        insertions,
-        ..
-      } = aln;
+  Ok({
+    let AlignWithNextcladeOutput {
+      substitutions,
+      deletions,
+      insertions,
+      ..
+    } = align_with_nextclade(ref_seq, qry_seq, &params)?;
 
-      let subs = substitutions
-        .iter()
-        .map(|s| Sub::new(s.pos.inner as usize, from_nuc(s.qry_nuc)))
-        .collect_vec();
+    let subs = substitutions
+      .iter()
+      .map(|s| Sub::new(s.pos.inner as usize, from_nuc(s.qry_nuc)))
+      .collect_vec();
 
-      let dels = deletions
-        .iter()
-        .map(|d| Del::new(d.range().begin.inner as usize, d.range().len()))
-        .collect_vec();
+    let dels = deletions
+      .iter()
+      .map(|d| Del::new(d.range().begin.inner as usize, d.range().len()))
+      .collect_vec();
 
-      // pangraph convention: location of insertion is the position *after* the insertion -> increment pos by 1
-      let inss = insertions
-        .iter()
-        .map(|s| Ins::new((s.pos + 1) as usize, from_nuc_seq(&s.ins)))
-        .collect_vec();
+    // pangraph convention: location of insertion is the position *after* the insertion -> increment pos by 1
+    let inss = insertions
+      .iter()
+      .map(|s| Ins::new((s.pos + 1) as usize, from_nuc_seq(&s.ins)))
+      .collect_vec();
 
-      Edit { subs, dels, inss }
-    }),
-  )
+    Edit { subs, dels, inss }
+  })
 }
 
 #[cfg(test)]

--- a/packages/pangraph/src/align/nextclade/align/align.rs
+++ b/packages/pangraph/src/align/nextclade/align/align.rs
@@ -44,13 +44,6 @@ pub fn align_nuc_simplestripe(
     );
   }
 
-  if ref_len + qry_len < (20 * params.kmer_length) {
-    // for very short sequences, use full square
-    let stripes = full_matrix(ref_len, qry_len);
-    trace!("In nucleotide alignment: Band construction: short sequences, using full matrix");
-    return Ok(align_pairwise(qry_seq, ref_seq, gap_open_close, params, &stripes));
-  }
-
   // mean shift equal to half difference between ref and query lengths
   let mean_shift = (ref_len as i32 - qry_len as i32) / 2;
   // band width equal to 2 times absolute difference + 10

--- a/packages/pangraph/src/align/nextclade/align_with_nextclade.rs
+++ b/packages/pangraph/src/align/nextclade/align_with_nextclade.rs
@@ -1,4 +1,4 @@
-use crate::align::nextclade::align::align::align_nuc;
+use crate::align::nextclade::align::align::align_nuc_simplestripe;
 use crate::align::nextclade::align::backtrace::AlignmentOutput;
 use crate::align::nextclade::align::gap_open::get_gap_open_close_scores_flat;
 use crate::align::nextclade::align::insertions_strip::{insertions_strip, Insertion};
@@ -26,51 +26,46 @@ pub fn align_with_nextclade(
   reff: impl AsRef<str>,
   qry: impl AsRef<str>,
   params: &NextalignParams,
-) -> Result<Option<AlignWithNextcladeOutput>, Report> {
+) -> Result<AlignWithNextcladeOutput, Report> {
   let ref_seq = to_nuc_seq(reff.as_ref()).wrap_err("When converting reference sequence")?;
   let qry_seq = to_nuc_seq(qry.as_ref()).wrap_err("When converting query sequence")?;
-  let seed_index = CodonSpacedIndex::from_sequence(&ref_seq);
   let gap_open_close = get_gap_open_close_scores_flat(&ref_seq, params);
 
-  let alignment =
-    align_nuc(0, "", &qry_seq, &ref_seq, &seed_index, &gap_open_close, params).wrap_err("When aligning sequences")?;
+  let alignment = align_nuc_simplestripe(&qry_seq, &ref_seq, &gap_open_close, params)
+    .wrap_err("When aligning sequences with nextclade align")?;
 
-  alignment
-    .map(|alignment| {
-      // println!("{:?}", alignment);
-      let stripped = insertions_strip(&alignment.qry_seq, &alignment.ref_seq);
+  // println!("{:?}", alignment);
+  let stripped = insertions_strip(&alignment.qry_seq, &alignment.ref_seq);
 
-      let FindNucChangesOutput {
-        substitutions,
-        deletions,
-        alignment_range,
-      } = find_nuc_changes(&stripped.qry_seq, &ref_seq);
+  let FindNucChangesOutput {
+    substitutions,
+    deletions,
+    alignment_range,
+  } = find_nuc_changes(&stripped.qry_seq, &ref_seq);
 
-      // NB: in nextclade aligner initial/final gaps are not saved as deletions,
-      // but they are recorded as limits in the alignment range.
-      // We need to add them manually.
-      let mut deletions = deletions;
-      if alignment_range.begin.inner > 0 {
-        deletions.push(NucDelRange::from_usize(0, alignment_range.begin.inner as usize));
-      }
-      if (alignment_range.end.inner as usize) < ref_seq.len() {
-        deletions.push(NucDelRange::from_usize(
-          alignment_range.end.inner as usize,
-          ref_seq.len(),
-        ));
-      }
+  // NB: in nextclade aligner initial/final gaps are not saved as deletions,
+  // but they are recorded as limits in the alignment range.
+  // We need to add them manually.
+  let mut deletions = deletions;
+  if alignment_range.begin.inner > 0 {
+    deletions.push(NucDelRange::from_usize(0, alignment_range.begin.inner as usize));
+  }
+  if (alignment_range.end.inner as usize) < ref_seq.len() {
+    deletions.push(NucDelRange::from_usize(
+      alignment_range.end.inner as usize,
+      ref_seq.len(),
+    ));
+  }
 
-      Ok(AlignWithNextcladeOutput {
-        qry_aln: from_nuc_seq(&stripped.qry_seq), // returns query with stripped insertions (regions with gap on reference)
-        // so that len(qry_aln) == len(ref_seq)
-        ref_aln: from_nuc_seq(&alignment.ref_seq), // returns reference sequence with all gaps.
-        substitutions,
-        deletions,
-        insertions: stripped.insertions,
-        is_reverse_complement: alignment.is_reverse_complement,
-      })
-    })
-    .transpose()
+  Ok(AlignWithNextcladeOutput {
+    qry_aln: from_nuc_seq(&stripped.qry_seq), // returns query with stripped insertions (regions with gap on reference)
+    // so that len(qry_aln) == len(ref_seq)
+    ref_aln: from_nuc_seq(&alignment.ref_seq), // returns reference sequence with all gaps.
+    substitutions,
+    deletions,
+    insertions: stripped.insertions,
+    is_reverse_complement: alignment.is_reverse_complement,
+  })
 }
 
 #[cfg(test)]
@@ -96,7 +91,7 @@ mod tests {
       ..NextalignParams::default()
     };
 
-    let actual = align_with_nextclade(ref_seq, qry_seq, &params)?.unwrap();
+    let actual = align_with_nextclade(ref_seq, qry_seq, &params)?;
 
     let expected = AlignWithNextcladeOutput {
       qry_aln,
@@ -156,7 +151,7 @@ mod tests {
       ..NextalignParams::default()
     };
 
-    let actual = align_with_nextclade(ref_seq, qry_seq, &params)?.unwrap();
+    let actual = align_with_nextclade(ref_seq, qry_seq, &params)?;
 
     let expected = AlignWithNextcladeOutput {
       qry_aln,
@@ -221,7 +216,7 @@ mod tests {
       ..NextalignParams::default()
     };
 
-    let actual = align_with_nextclade(ref_seq, qry_seq, &params)?.unwrap();
+    let actual = align_with_nextclade(ref_seq, qry_seq, &params)?;
 
     let subs = [
       (9, Nuc::A),

--- a/packages/pangraph/src/distance/mash/mash_distance.rs
+++ b/packages/pangraph/src/distance/mash/mash_distance.rs
@@ -126,8 +126,19 @@ mod tests {
   }
 
   #[rstest]
+  fn test_mash_distance_equal() {
+    let graphs = vec![
+      "CATAGAAGCAGTCCCTGAGCACGACGCGTGTAACAATCGTTTTCAGACCTAGGACGTTAGAATATCGATCGCACGCTACGACCGACGATTAGCCGCACGAGCAAGTCGAAAACCCGAGTTAAGAGGCTGGACGTGATCCTAGACTTCGTC",
+      "CATAGAAGCAGTCCCTGAGCACGACGCGTGTAACAATCGTTTTCAGACCTAGGACGTTAGAATATCGATCGCACGCTACGACCGACGATTAGCCGCACGAGCAAGTCGAAAACCCGAGTTAAGAGGCTGGACGTGATCCTAGACTTCGTC",
+    ].into_iter().map(create_fake_graph).collect_vec();
+    let actual = mash_distance(&graphs, &MinimizersParams::default());
+    let expected = array![[0., 0.], [0., 0.],];
+    assert_eq!(actual, expected);
+  }
+
+  #[rstest]
   fn test_mash_distance_one() {
-    let graphs = [create_fake_graph("ATGCATGC")];
+    let graphs = [create_fake_graph("CATAGAAGCAGTCCCTGAGCACGACGCGTGTAACAATCGTTTTCAGACCTA")];
     let actual = mash_distance(&graphs, &MinimizersParams::default());
     let expected = array![[0.0]];
     assert_eq!(actual, expected);

--- a/packages/pangraph/src/distance/mash/mash_distance.rs
+++ b/packages/pangraph/src/distance/mash/mash_distance.rs
@@ -16,7 +16,10 @@ pub fn mash_distance(graphs: &[Pangraph], params: &MinimizersParams) -> Array2<f
 
   let minimizers = sequences
     .enumerate()
-    .flat_map(|(i, seq)| minimizers_sketch(seq, i as u64, params))
+    .flat_map(|(i, seq)| {
+      minimizers_sketch(seq, i as u64, params)
+        .expect("no minimizer found for a sequence during mash distance evaluation")
+    })
     .sorted_by_key(|minimizer| minimizer.value)
     .collect_vec();
 
@@ -47,6 +50,12 @@ pub fn mash_distance(graphs: &[Pangraph], params: &MinimizersParams) -> Array2<f
   }
 
   for i in 0..n {
+    assert!(
+      distance[(i, i)] > 0.,
+      "no self-hit found for sequence {}. This will make neighbor joining fail",
+      i
+    );
+
     for j in (i + 1)..n {
       distance[(i, j)] = 1.0 - distance[(i, j)] / distance[(i, i)];
       distance[(j, i)] = distance[(i, j)];

--- a/packages/pangraph/src/pangraph/reweave.rs
+++ b/packages/pangraph/src/pangraph/reweave.rs
@@ -39,10 +39,32 @@ impl MergePromise {
       .par_iter()
       .map(|(node_id, edits)| {
         let mut seq = edits.apply(self.append_block.consensus())?;
+
+        // debug assert: check that length of sequence is > 0
+        // if not, return an error and print the results for debug
+        debug_assert!(
+          !seq.is_empty(),
+          "Sequence {:?} is empty after applying edits: {:#?}",
+          self.append_block.consensus(),
+          edits
+        );
+
         if !self.orientation.is_forward() {
           seq = reverse_complement(&seq)?;
         };
+        let seq_cpy = seq.clone(); // TODO: for debug check, remove befor merging PR
         let edits = map_variations(self.anchor_block.consensus(), seq)?;
+
+        // check that input and output sequences are the same after edits
+        debug_assert!(
+          seq_cpy == edits.apply(self.anchor_block.consensus())?,
+          "After applying edits, the sequence\n{:?} is not equal to the original input sequence\n{:?}.\nEdits: {:#?}, Anchor block consensus: {:#?}",
+          edits.apply(self.anchor_block.consensus())?,
+          seq_cpy,
+          edits,
+          self.anchor_block.consensus()
+        );
+
         Ok((*node_id, edits))
       })
       .collect::<Result<Vec<_>, Report>>()?

--- a/packages/pangraph/src/pangraph/reweave.rs
+++ b/packages/pangraph/src/pangraph/reweave.rs
@@ -54,7 +54,7 @@ impl MergePromise {
         //   edits
         // );
 
-        let seq_cpy = seq.clone(); // TODO: remove check before release
+        // let seq_cpy = seq.clone(); // TODO: remove check before release
 
         let edits = match seq.is_empty() {
           true => Edit {
@@ -66,14 +66,14 @@ impl MergePromise {
         };
 
         // check that input and output sequences are the same after edits
-        debug_assert!(
-          seq_cpy == edits.apply(self.anchor_block.consensus())?,
-          "After applying edits, the sequence\n{:?} is not equal to the original input sequence\n{:?}.\nEdits: {:#?}, Anchor block consensus: {:#?}",
-          edits.apply(self.anchor_block.consensus())?,
-          seq_cpy,
-          edits,
-          self.anchor_block.consensus()
-        );
+        // debug_assert!(
+        //   seq_cpy == edits.apply(self.anchor_block.consensus())?,
+        //   "After applying edits, the sequence\n{:?} is not equal to the original input sequence\n{:?}.\nEdits: {:#?}, Anchor block consensus: {:#?}",
+        //   edits.apply(self.anchor_block.consensus())?,
+        //   seq_cpy,
+        //   edits,
+        //   self.anchor_block.consensus()
+        // );
 
         Ok((*node_id, edits))
       })


### PR DESCRIPTION
**problem**:
in the current version of the block-merging algorithm, we use nextalign to append new sequences to a block by aligning them to the block consensus. However the alignment function used, based on seed matching and extending, will fail when the consensus is too short and no seeds are found.
Moreover this method requires the aligner to create a seed index for the two sequences every time. Other than being computationally expensive, this operation is in principle superfluous, since homology between the two sequences, with indels smaller than the threshold length, is a prerequisite of block merging.

**solution**:
Given these premises, we can solve the problem by aligning the two sequences with the `align_pairwise` function with a simple stripe, whose width is proportional to the length difference between the two sequences.

**changes**:
- modified the pairwise alignment as described above. Now even short sequences can be aligned without raising errors.
- fixed a test input file `sc2.fa`. This file contained an error: a new line was missing between one sequence and the next. The sequence with the missing new line was identical to a previous one. I added the new line but left the identical sequence to make sure that pangraph will not fail.
- improved minimizers error handling: I now raise an error when no minimizers are found for a sequence. This makes the failure more informative. Otherwise the neighbour joining will fail later on.