### PR TITLE
Fix/verify

### DIFF
--- a/packages/pangraph/src/commands/reconstruct/reconstruct_run.rs
+++ b/packages/pangraph/src/commands/reconstruct/reconstruct_run.rs
@@ -70,11 +70,16 @@ fn reconstruct_path_sequence(graph: &Pangraph, path: &PangraphPath) -> Result<St
 
   let first_node_id = path.nodes.first().ok_or_else(|| make_internal_report!("Empty path"))?;
   let first_node_pos = graph.nodes.get(first_node_id).unwrap().position().0;
+
   let genome: String = path
     .nodes
     .iter()
     .map(|node_id| reconstruct_block_sequence(graph, *node_id).unwrap())
     .collect();
+
+  if first_node_pos == 0 {
+    return Ok(genome);
+  }
 
   let genome_len = path.tot_len();
   assert_eq!(genome.len(), genome_len);


### PR DESCRIPTION
update sequence reconstruction function to deal with cases when the path start does not correspond to the sequence start.
This should only be relevant for circular genomes.
When the start position $k$ of the first path node on the input genome is $k \neq 0$, then chops the path sequence in two at index $L-k$, where $L$ is the total path length, and inverts the two pieces. This way the first node now starts at position $k$ in the new sequence.