### PR TITLE
fix edge case in block concatenation

### DIFF
--- a/packages/pangraph/src/pangraph/edits.rs
+++ b/packages/pangraph/src/pangraph/edits.rs
@@ -167,13 +167,23 @@ impl Edit {
     }
   }
 
-  pub fn concat(&self, other: &Self) -> Self {
+  pub fn concat(&self, next: &Self) -> Self {
     let mut inss = self.inss.clone();
     let mut dels = self.dels.clone();
     let mut subs = self.subs.clone();
-    inss.extend(other.inss.iter().cloned());
-    dels.extend(other.dels.iter().cloned());
-    subs.extend(other.subs.iter().cloned());
+
+    // if two insertions have the same position,
+    // concatenate self + next
+    for ins in &next.inss {
+      if let Some(prev) = inss.iter_mut().find(|i| i.pos == ins.pos) {
+        prev.seq.push_str(&ins.seq);
+      } else {
+        inss.push(ins.clone());
+      }
+    }
+
+    dels.extend(next.dels.iter().cloned());
+    subs.extend(next.subs.iter().cloned());
     Self { subs, dels, inss }
   }
 


### PR DESCRIPTION
There was an error happening when merging transitive edges. This was due to the following edge-case:
- consider the concatenation of two blocks `b1` and `b2`.
- `b1` has an insertion at the end of the block, at position `L1`
- `b2` has an insertion at the beginning of the block, at position `0`
- when concatenating them into a new block `b1+b2` there will be two insertions at position `L1`, the boundary between the two original blocks. And there is an ambiguity on which one to apply first.

To fix this at the moment of merging the two sets of insertions, if two have the same position I join them in a single insertion, appending the second one to the first one.