### PR TITLE
Fix/export tests

### DIFF
--- a/packages/pangraph/src/circularize/circularize_utils.rs
+++ b/packages/pangraph/src/circularize/circularize_utils.rs
@@ -58,6 +58,20 @@ impl Edge {
   pub fn oriented_equal(&self, other: &Edge) -> bool {
     self.n1 == other.n1 && self.n2 == other.n2
   }
+
+  pub fn smaller_bid_first(&self) -> Edge {
+    if self.n1.bid < self.n2.bid {
+      *self
+    } else {
+      self.invert()
+    }
+  }
+
+  pub fn to_tuple(&self) -> (BlockId, BlockId, isize, isize) {
+    let s1 = if self.n1.strand == Strand::Forward { 0 } else { 1 };
+    let s2 = if self.n2.strand == Strand::Forward { 0 } else { 1 };
+    (self.n1.bid, self.n2.bid, s1, s2)
+  }
 }
 
 impl PartialEq for Edge {

--- a/packages/pangraph/src/commands/export/export_core_genome.rs
+++ b/packages/pangraph/src/commands/export/export_core_genome.rs
@@ -150,6 +150,35 @@ mod tests {
 
   #[test]
   fn test_core_block_aln_general_case() {
+    // path A: n1+, n2-
+    // path B: n4+, n5+, n3-
+
+    // block 1:
+    // cons: ACCTATCGTGATCGTTCGAT
+    // A n1: ACCTATCGT---CGTTCGAT
+    // B n3: ACTTATCGTGATCGTTCGAT
+    // reverse-complement:
+    // cons: ATCGAACGATCACGATAGGT
+    // A n1: ATCGAACG---ACGATAGGT
+    // B n3: ATCGAACGATCACGATAAGT
+
+    // block 2:
+    // cons: CTGCAA   GTCTGATCTAGTTA
+    // A n2: CTGCAATTTGTCTGATGTAGTTA
+    // B n4: CT--AA   GTCTGATCTAGTTA
+    // reverse-complement
+    // cons: TAACTAGATCAGAC   TTGCAG
+    // A n2: TAACTACATCAGACAAATTGCAG
+    // B n4: TAACTAGATCAGAC   TT--AG
+
+    // core (guide A):
+    // A: ACCTATCGT---CGTTCGATTAACTACATCAGACAAATTGCAG
+    // B: ACTTATCGTGATCGTTCGATTAACTAGATCAGAC   TT--AG
+
+    // core (guide B):
+    // A: CTGCAATTTGTCTGATGTAGTTAATCGAACG---ACGATAGGT
+    // B: CT--AA   GTCTGATCTAGTTAATCGAACGATCACGATAAGT
+
     let graph = Pangraph::from_str(indoc! {
     // language=json
     r#"
@@ -158,14 +187,14 @@ mod tests {
           "0": {
             "id": 0,
             "nodes": [1, 2],
-            "tot_len": 100,
+            "tot_len": 40,
             "circular": false,
             "name": "Path A"
           },
           "1": {
             "id": 1,
-            "nodes": [3, 4],
-            "tot_len": 100,
+            "nodes": [4, 5, 3],
+            "tot_len": 48,
             "circular": false,
             "name": "Path B"
           }
@@ -173,15 +202,15 @@ mod tests {
         "blocks": {
           "1": {
             "id": 1,
-            "consensus": "ACGTACGT",
+            "consensus": "ACCTATCGTGATCGTTCGAT",
             "alignments": {
               "1": {
                 "subs": [],
-                "dels": [],
+                "dels": [{"pos": 9, "len": 3}],
                 "inss": []
               },
-              "2": {
-                "subs": [{"pos": 3, "alt": "T"}],
+              "3": {
+                "subs": [{"pos": 2, "alt": "T"}],
                 "dels": [],
                 "inss": []
               }
@@ -189,17 +218,28 @@ mod tests {
           },
           "2": {
             "id": 2,
-            "consensus": "TTGCA",
+            "consensus": "CTGCAAGTCTGATCTAGTTA",
             "alignments": {
-              "3": {
-                "subs": [],
-                "dels": [{"pos": 2, "len": 1}],
-                "inss": []
+              "2": {
+                "subs": [{"pos": 13, "alt": "G"}],
+                "dels": [],
+                "inss": [{"pos": 6, "seq": "TTT"}]
               },
               "4": {
                 "subs": [],
+                "dels": [{"pos": 2, "len": 2}],
+                "inss": []
+              }
+            }
+          },
+          "3": {
+            "id": 3,
+            "consensus": "AGGCTACGAT",
+            "alignments": {
+              "5": {
+                "subs": [],
                 "dels": [],
-                "inss": [{"pos": 0, "seq": "AAA"}]
+                "inss": []
               }
             }
           }
@@ -210,28 +250,35 @@ mod tests {
             "block_id": 1,
             "path_id": 0,
             "strand": "+",
-            "position": [0, 8]
+            "position": [0, 17]
           },
           "2": {
             "id": 2,
-            "block_id": 1,
+            "block_id": 2,
             "path_id": 0,
             "strand": "-",
-            "position": [0, 8]
+            "position": [17, 40]
           },
           "3": {
             "id": 3,
-            "block_id": 2,
+            "block_id": 1,
             "path_id": 1,
-            "strand": "+",
-            "position": [0, 5]
+            "strand": "-",
+            "position": [28, 48]
           },
           "4": {
             "id": 4,
             "block_id": 2,
             "path_id": 1,
             "strand": "+",
-            "position": [0, 5]
+            "position": [0, 18]
+          },
+          "5": {
+            "id": 5,
+            "block_id": 3,
+            "path_id": 1,
+            "strand": "+",
+            "position": [18, 28]
           }
         }
       }
@@ -240,10 +287,55 @@ mod tests {
 
     let params = ExportCoreAlignmentParams {
       guide_strain: o!("Path A"),
+      unaligned: false,
+    };
+
+    let expected = vec![
+      (o!("Path A"), o!("ACCTATCGT---CGTTCGATTAACTACATCAGACTTGCAG")),
+      (o!("Path B"), o!("ACTTATCGTGATCGTTCGATTAACTAGATCAGACTT--AG")),
+    ];
+    let actual = core_block_aln(&graph, &params).unwrap();
+
+    assert_eq!(expected, actual);
+
+    let params = ExportCoreAlignmentParams {
+      guide_strain: o!("Path A"),
       unaligned: true,
     };
 
-    let expected = vec![(o!("Path A"), o!("ACGTTGTCA--")), (o!("Path B"), o!("TT--CGAATTTGCA"))];
+    let expected = vec![
+      (o!("Path A"), o!("ACCTATCGTCGTTCGATTAACTACATCAGACAAATTGCAG")),
+      (o!("Path B"), o!("ACTTATCGTGATCGTTCGATTAACTAGATCAGACTTAG")),
+    ];
+
+    let actual = core_block_aln(&graph, &params).unwrap();
+
+    assert_eq!(expected, actual);
+
+    let params = ExportCoreAlignmentParams {
+      guide_strain: o!("Path B"),
+      unaligned: false,
+    };
+
+    let expected = vec![
+      (o!("Path A"), o!("CTGCAAGTCTGATGTAGTTAATCGAACG---ACGATAGGT")),
+      (o!("Path B"), o!("CT--AAGTCTGATCTAGTTAATCGAACGATCACGATAAGT")),
+    ];
+
+    let actual = core_block_aln(&graph, &params).unwrap();
+
+    assert_eq!(expected, actual);
+
+    let params = ExportCoreAlignmentParams {
+      guide_strain: o!("Path B"),
+      unaligned: true,
+    };
+
+    let expected = vec![
+      (o!("Path A"), o!("CTGCAATTTGTCTGATGTAGTTAATCGAACGACGATAGGT")),
+      (o!("Path B"), o!("CTAAGTCTGATCTAGTTAATCGAACGATCACGATAAGT")),
+    ];
+
     let actual = core_block_aln(&graph, &params).unwrap();
 
     assert_eq!(expected, actual);

--- a/packages/pangraph/src/io/gfa.rs
+++ b/packages/pangraph/src/io/gfa.rs
@@ -1,12 +1,12 @@
+use crate::circularize::circularize_utils::{Edge, SimpleNode};
 use crate::io::file::create_file_or_stdout;
 use crate::pangraph::pangraph::Pangraph;
 use crate::pangraph::pangraph_block::BlockId;
 use crate::pangraph::strand::Strand;
 use clap::Parser;
-use derive_more::Constructor;
 use eyre::{Context, Report};
 use itertools::Itertools;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::io::Write;
 use std::path::Path;
 
@@ -104,7 +104,22 @@ pub fn gfa_write<W: Write>(mut writer: W, g: &Pangraph, params: &GfaWriteParams)
     writeln!(writer, "# edges")?;
   }
 
-  for (edge, read_count) in &gfa.links.edge_ct {
+  for (edge, read_count) in gfa
+    .links
+    .edge_ct
+    .iter()
+    .map(|(edge, &read_count)| {
+      (
+        if edge.n1.bid > edge.n2.bid {
+          edge.invert()
+        } else {
+          *edge
+        },
+        read_count,
+      )
+    })
+    .sorted_by_key(|(edge, _)| (edge.n1.bid, edge.n2.bid))
+  {
     let bid1 = edge.n1.bid;
     let strand1 = edge.n1.strand;
     let bid2 = edge.n2.bid;
@@ -144,21 +159,9 @@ pub struct GfaSegment {
   duplicated: bool,
 }
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Constructor)]
-pub struct SimpleNode {
-  bid: BlockId,
-  strand: Strand,
-}
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Constructor)]
-pub struct Edge {
-  n1: SimpleNode,
-  n2: SimpleNode,
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct GfaLinks {
-  edge_ct: BTreeMap<Edge, usize>,
+  edge_ct: HashMap<Edge, usize>,
 }
 
 impl GfaLinks {
@@ -300,95 +303,144 @@ mod tests {
 
   #[test]
   fn test_gfa_general_case() {
+    // graph (circular):
+    // path A: 1+ -> 2- -> 3+
+    //         n1    n2    n3
+    // path B: 2+ -> 1- -> 3+ -> 4+
+    //         n4    n5    n6    n7
     let g = Pangraph::from_str(indoc! {
     // language=json
     r#"
-    {
-      "paths": {
-        "0": {
-          "id": 0,
-          "nodes": [
-            14515840915932838377
-          ],
-          "tot_len": 1737,
-          "circular": false,
-          "name": "Path A"
+      {
+        "paths": {
+          "0": {
+            "id": 0,
+            "nodes": [1, 2, 3],
+            "tot_len": 50,
+            "circular": true,
+            "name": "Path A"
+          },
+          "1": {
+            "id": 1,
+            "nodes": [4, 5, 6, 7],
+            "tot_len": 60,
+            "circular": true,
+            "name": "Path B"
+          }
         },
-        "1": {
-          "id": 1,
-          "nodes": [
-            15291847754458130853
-          ],
-          "tot_len": 1737,
-          "circular": false,
-          "name": "Path B"
-        },
-        "2": {
-          "id": 2,
-          "nodes": [
-            15109482180931348145
-          ],
-          "tot_len": 1737,
-          "circular": false,
-          "name": "Path C"
-        }
-      },
-      "blocks": {
-        "12778560093473594666": {
-          "id": 12778560093473594666,
-          "consensus": "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT",
-          "alignments": {
-            "14515840915932838377": {
-              "subs": [],
-              "dels": [],
-              "inss": []
-            },
-            "15291847754458130853": {
-              "subs": [],
-              "dels": [],
-              "inss": []
-            },
-            "15109482180931348145": {
-              "subs": [],
-              "dels": [],
-              "inss": []
+        "blocks": {
+          "1": {
+            "id": 1,
+            "consensus": "ACCTATCGTGATCGTTCGAT",
+            "alignments": {
+              "1": {
+                "subs": [],
+                "dels": [],
+                "inss": []
+              },
+              "4": {
+                "subs": [],
+                "dels": [],
+                "inss": []
+              }
+            }
+          },
+          "2": {
+            "id": 2,
+            "consensus": "CTGCAAGTCTGATCTAGTTA",
+            "alignments": {
+              "2": {
+                "subs": [],
+                "dels": [],
+                "inss": []
+              },
+              "6": {
+                "subs": [],
+                "dels": [],
+                "inss": []
+              }
+            }
+          },
+          "3": {
+            "id": 3,
+            "consensus": "AGGCTACGAT",
+            "alignments": {
+              "3": {
+                "subs": [],
+                "dels": [],
+                "inss": []
+              },
+              "5": {
+                "subs": [],
+                "dels": [],
+                "inss": []
+              }
+            }
+          },
+          "4": {
+            "id": 4,
+            "consensus": "CTTCAGCAAG",
+            "alignments": {
+              "7": {
+                "subs": [],
+                "dels": [],
+                "inss": []
+              }
             }
           }
-        }
-      },
-      "nodes": {
-        "14515840915932838377": {
-          "id": 14515840915932838377,
-          "block_id": 12778560093473594666,
-          "path_id": 0,
-          "strand": "+",
-          "position": [
-            0,
-            0
-          ]
         },
-        "15291847754458130853": {
-          "id": 15291847754458130853,
-          "block_id": 12778560093473594666,
-          "path_id": 1,
-          "strand": "+",
-          "position": [
-            0,
-            0
-          ]
-        },
-        "15109482180931348145": {
-          "id": 15109482180931348145,
-          "block_id": 12778560093473594666,
-          "path_id": 2,
-          "strand": "+",
-          "position": [
-            0,
-            0
-          ]
+        "nodes": {
+          "1": {
+            "id": 1,
+            "block_id": 1,
+            "path_id": 0,
+            "strand": "+",
+            "position": [0, 0]
+          },
+          "2": {
+            "id": 2,
+            "block_id": 2,
+            "path_id": 0,
+            "strand": "-",
+            "position": [0, 0]
+          },
+          "3": {
+            "id": 3,
+            "block_id": 3,
+            "path_id": 0,
+            "strand": "+",
+            "position": [0, 0]
+          },
+          "4": {
+            "id": 4,
+            "block_id": 2,
+            "path_id": 1,
+            "strand": "+",
+            "position": [0, 0]
+          },
+          "5": {
+            "id": 5,
+            "block_id": 1,
+            "path_id": 1,
+            "strand": "-",
+            "position": [0, 0]
+          },
+          "6": {
+            "id": 6,
+            "block_id": 3,
+            "path_id": 1,
+            "strand": "+",
+            "position": [0, 0]
+          },
+          "7": {
+            "id": 7,
+            "block_id": 4,
+            "path_id": 1,
+            "strand": "+",
+            "position": [0, 0]
+          }
         }
       }
-    }
     "#})
     .unwrap();
 
@@ -401,13 +453,21 @@ mod tests {
 
     let expected = indoc! {r#"
     H	VN:Z:1.0
-    S	12778560093473594666	ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT
-    L	A	-	B	+	1M
-    L	A	-	B	+	1M
-    L	A	-	B	+	1M
-    P	Path A	12778560093473594666	*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*
-    P	Path B	12778560093473594666	*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*
-    P	Path C	12778560093473594666	*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*
+    # blocks
+    S	1	ACCTATCGTGATCGTTCGAT	RC:i:40	LN:i:20
+    S	2	CTGCAAGTCTGATCTAGTTA	RC:i:40	LN:i:20
+    S	3	AGGCTACGAT	RC:i:20	LN:i:10
+    S	4	CTTCAGCAAG	RC:i:10	LN:i:10
+    # edges
+    L	1	+	2	-	*	RC:i:2
+    L	1	-	3	-	*	RC:i:1
+    L	1	-	3	+	*	RC:i:1
+    L	2	-	3	+	*	RC:i:1
+    L	2	-	4	-	*	RC:i:1
+    L	3	+	4	+	*	RC:i:1
+    # paths
+    P	Path A	1+,2-,3+	*	TP:Z:circular
+    P	Path B	2+,1-,3+,4+	*	TP:Z:circular
     "#};
 
     assert_eq!(expected, actual);

--- a/packages/pangraph/src/io/gfa.rs
+++ b/packages/pangraph/src/io/gfa.rs
@@ -108,17 +108,9 @@ pub fn gfa_write<W: Write>(mut writer: W, g: &Pangraph, params: &GfaWriteParams)
     .links
     .edge_ct
     .iter()
-    .map(|(edge, &read_count)| {
-      (
-        if edge.n1.bid > edge.n2.bid {
-          edge.invert()
-        } else {
-          *edge
-        },
-        read_count,
-      )
-    })
-    .sorted_by_key(|(edge, _)| (edge.n1.bid, edge.n2.bid))
+    .map(|(edge, &read_count)| (edge.smaller_bid_first(), read_count)) // sort by smaller bid first
+    .sorted_by_key(|(edge, _)| edge.to_tuple())
+  // sort by (bid1, bid2, strand1, strand2)
   {
     let bid1 = edge.n1.bid;
     let strand1 = edge.n1.strand;
@@ -460,8 +452,8 @@ mod tests {
     S	4	CTTCAGCAAG	RC:i:10	LN:i:10
     # edges
     L	1	+	2	-	*	RC:i:2
-    L	1	-	3	-	*	RC:i:1
     L	1	-	3	+	*	RC:i:1
+    L	1	-	3	-	*	RC:i:1
     L	2	-	3	+	*	RC:i:1
     L	2	-	4	-	*	RC:i:1
     L	3	+	4	+	*	RC:i:1


### PR DESCRIPTION
I corrected and extended tests for core-genome alignment export and gfa export.

concerning the **core-genome alignment** export:
- I use a vector of blocks instead of a Btree for the blocks on the guide strain. If I understand correctly when iterating over the latter one gets blocks in the order of the key (the block id) while we want to maintain the order of the guide strain.
- I extended the test with a more complete example, that involves different orders for different guide strains and different strandedness of different blocks

concerning the **gfa export**:
- I removed the implementation of `Edge` and use the one already present in `circularize`, that is invariant under edge inversion. In this way edges traversed in different directions are still reported only once.
- I added a more complete test example.

![image](https://github.com/user-attachments/assets/816a9c74-10f0-4ccc-94b9-fa6c976c0122)
