### PR TITLE
fix: node positions

### DIFF
--- a/packages/pangraph/src/pangraph/pangraph.rs
+++ b/packages/pangraph/src/pangraph/pangraph.rs
@@ -30,7 +30,8 @@ impl Pangraph {
     let block_id = BlockId(fasta.index);
     let block = PangraphBlock::from_consensus(fasta.seq, block_id, node_id);
     let path_id = PathId(fasta.index);
-    let node = PangraphNode::new(Some(node_id), block.id(), path_id, strand, (0, 0));
+    let node_position = if circular { (0, 0) } else { (0, tot_len) }; // path wraps around if circular
+    let node = PangraphNode::new(Some(node_id), block.id(), path_id, strand, node_position);
     let path = PangraphPath::new(Some(path_id), [node.id()], tot_len, circular, Some(fasta.seq_name));
     Self {
       blocks: btreemap! {block.id() => block},

--- a/packages/pangraph/src/pangraph/reweave.rs
+++ b/packages/pangraph/src/pangraph/reweave.rs
@@ -528,9 +528,9 @@ mod tests {
         },
       );
 
-      let p1 = PangraphPath::new(Some(PathId(100)), [nid1], 2000, false, None);
-      let p2 = PangraphPath::new(Some(PathId(200)), [nid2], 2000, false, None);
-      let p3 = PangraphPath::new(Some(PathId(300)), [nid3], 200, false, None);
+      let p1 = PangraphPath::new(Some(PathId(100)), [nid1], 2000, true, None);
+      let p2 = PangraphPath::new(Some(PathId(200)), [nid2], 2000, true, None);
+      let p3 = PangraphPath::new(Some(PathId(300)), [nid3], 200, true, None);
 
       let G = Pangraph {
         paths: btreemap! {
@@ -683,9 +683,9 @@ mod tests {
       };
 
       let paths = btreemap! {
-        PathId(100) => PangraphPath::new(Some(PathId(100)), [NodeId(1), NodeId(2)], 1000, false, None),
-        PathId(200) => PangraphPath::new(Some(PathId(200)), [NodeId(3), NodeId(4), NodeId(5)], 1000, false, None),
-        PathId(300) => PangraphPath::new(Some(PathId(300)), [NodeId(6), NodeId(7), NodeId(8)], 1000, false, None),
+        PathId(100) => PangraphPath::new(Some(PathId(100)), [NodeId(1), NodeId(2)], 1000, true, None),
+        PathId(200) => PangraphPath::new(Some(PathId(200)), [NodeId(3), NodeId(4), NodeId(5)], 1000, true, None),
+        PathId(300) => PangraphPath::new(Some(PathId(300)), [NodeId(6), NodeId(7), NodeId(8)], 1000, true, None),
       };
 
       #[rustfmt::skip]


### PR DESCRIPTION
This is a follow-up fix for #102 
The previous PR fixed the edge-case for circular paths, but I realized that the debug assert would still fail for linear paths. 
This was due to the way we do slices for linear vs circular paths.

given a path of length 100, the segment `[0,100]` is now indexed `[0,0]` for circular paths, since start == end, but is indexed as `[0,100]` for linear paths.