### PR TITLE
update CLI help

### DIFF
--- a/packages/pangraph/src/align/alignment_args.rs
+++ b/packages/pangraph/src/align/alignment_args.rs
@@ -10,13 +10,13 @@ pub struct AlignmentArgs {
   #[clap(value_hint = ValueHint::Other)]
   pub indel_len_threshold: usize,
 
-  /// Energy cost for introducing junction due to alignment merger
+  /// Energy cost for splitting a block during alignment merger. Controls graph fragmentation, see documentation.
   #[default = 100.0]
   #[clap(long, short = 'a', default_value_t = AlignmentArgs::default().alpha)]
   #[clap(value_hint = ValueHint::Other)]
   pub alpha: f64,
 
-  /// Energy cost for interblock diversity due to alignment merger
+  /// Energy cost for diversity in the alignment. A high value prevents merging of distantly-related sequences in the same block, see documentation.
   #[default = 10.0]
   #[clap(long, short = 'b', default_value_t = AlignmentArgs::default().beta)]
   #[clap(value_hint = ValueHint::Other)]

--- a/packages/pangraph/src/circularize/circularize_utils.rs
+++ b/packages/pangraph/src/circularize/circularize_utils.rs
@@ -58,6 +58,20 @@ impl Edge {
   pub fn oriented_equal(&self, other: &Edge) -> bool {
     self.n1 == other.n1 && self.n2 == other.n2
   }
+
+  pub fn smaller_bid_first(&self) -> Edge {
+    if self.n1.bid < self.n2.bid {
+      *self
+    } else {
+      self.invert()
+    }
+  }
+
+  pub fn to_tuple(&self) -> (BlockId, BlockId, isize, isize) {
+    let s1 = if self.n1.strand == Strand::Forward { 0 } else { 1 };
+    let s2 = if self.n2.strand == Strand::Forward { 0 } else { 1 };
+    (self.n1.bid, self.n2.bid, s1, s2)
+  }
 }
 
 impl PartialEq for Edge {

--- a/packages/pangraph/src/circularize/circularize_utils.rs
+++ b/packages/pangraph/src/circularize/circularize_utils.rs
@@ -59,14 +59,19 @@ impl Edge {
     self.n1 == other.n1 && self.n2 == other.n2
   }
 
-  pub fn smaller_bid_first(&self) -> Edge {
-    if self.n1.bid < self.n2.bid {
+  // orient such that the first node has a lower block id
+  // if block ids are equal, orient such that the first node has a forward strand
+  // if possible
+  pub fn conventional_orientation(&self) -> Edge {
+    if (self.n1.bid < self.n2.bid) || (self.n1.bid == self.n2.bid && self.n1.strand == Strand::Forward) {
       *self
     } else {
       self.invert()
     }
   }
 
+  // returns a tuple (bid1, bid2, 0/1, 0/1) where 0/1 indicates the strand
+  // used to decide ordering between different edges
   pub fn to_tuple(&self) -> (BlockId, BlockId, isize, isize) {
     let s1 = if self.n1.strand == Strand::Forward { 0 } else { 1 };
     let s2 = if self.n2.strand == Strand::Forward { 0 } else { 1 };

--- a/packages/pangraph/src/commands/build/build_args.rs
+++ b/packages/pangraph/src/commands/build/build_args.rs
@@ -63,10 +63,6 @@ pub struct PangraphBuildArgs {
   #[clap(long, short = 'c')]
   pub circular: bool,
 
-  /// Transforms all sequences to upper case
-  #[clap(long, short = 'u')]
-  pub upper_case: bool,
-
   /// Maximum number of alignment rounds to consider per pairwise graph merger
   #[clap(long, short = 'x', default_value_t = 100)]
   #[clap(value_hint = ValueHint::Other)]

--- a/packages/pangraph/src/commands/build/build_args.rs
+++ b/packages/pangraph/src/commands/build/build_args.rs
@@ -78,7 +78,7 @@ pub struct PangraphBuildArgs {
   #[clap(value_hint = ValueHint::Other)]
   pub alignment_kernel: AlignmentBackend,
 
-  /// Verify that the original sequences can be reconstructed from the resulting pangraph
+  /// Sanity check: after construction verifies that the original sequences can be reconstructed exactly from the resulting pangraph. Raises an error otherwise.
   #[clap(long, short = 'f')]
   pub verify: bool,
 }

--- a/packages/pangraph/src/commands/build/build_args.rs
+++ b/packages/pangraph/src/commands/build/build_args.rs
@@ -31,7 +31,7 @@ pub enum AlignmentBackend {
   Mmseqs,
 }
 
-/// Align genomes into a multiple sequence alignment graph
+/// Align genomes into a pangenome graph
 #[derive(Parser, Debug)]
 pub struct PangraphBuildArgs {
   /// Path(s) to zero, one or multiple FASTA files with input sequences. Multiple records within one file are treated as separate genomes.
@@ -85,8 +85,4 @@ pub struct PangraphBuildArgs {
   /// Verify that the original sequences can be reconstructed from the resulting pangraph
   #[clap(long, short = 'f')]
   pub verify: bool,
-
-  /// Random seed for block id generation
-  #[clap(long)]
-  pub seed: Option<u64>,
 }

--- a/packages/pangraph/src/commands/build/build_run.rs
+++ b/packages/pangraph/src/commands/build/build_run.rs
@@ -7,16 +7,13 @@ use crate::pangraph::pangraph::Pangraph;
 use crate::pangraph::strand::Strand::Forward;
 use crate::tree::clade::postorder;
 use crate::tree::neighbor_joining::build_tree_using_neighbor_joining;
-use crate::utils::random::get_random_number_generator;
 use crate::{make_internal_error, make_internal_report};
 use eyre::{Report, WrapErr};
 use itertools::Itertools;
 use log::info;
 
 pub fn build_run(args: &PangraphBuildArgs) -> Result<(), Report> {
-  let PangraphBuildArgs { input_fastas, seed, .. } = &args;
-
-  let rng = get_random_number_generator(seed);
+  let input_fastas = &args.input_fastas;
 
   let fastas = read_many_fasta(input_fastas)?;
 

--- a/packages/pangraph/src/commands/export/export_args.rs
+++ b/packages/pangraph/src/commands/export/export_args.rs
@@ -85,7 +85,7 @@ pub struct PangraphExportBlockSequencesArgs {
   #[clap(display_order = 1, value_hint = ValueHint::FilePath)]
   pub input_json: Option<PathBuf>,
 
-  /// Path to directory to write output FASTA files to
+  /// Path to directory to write output FASTA files to. Files are named `block_{block_id}.fa` in the folder.
   ///
   /// See: https://en.wikipedia.org/wiki/FASTA_format
   #[clap(long, short = 'o', value_hint = ValueHint::AnyPath)]

--- a/packages/pangraph/src/commands/export/export_args.rs
+++ b/packages/pangraph/src/commands/export/export_args.rs
@@ -17,10 +17,10 @@ pub enum PangraphExportArgs {
   /// Export block consensus sequences to a fasta file
   BlockConsensus(PangraphExportBlockConsensusArgs),
 
-  /// Export aligned or unaligned sequences for each block. Note that alignments exclude insertions
+  /// Export aligned or unaligned sequences for each block in separate fasta files. Note that alignments exclude insertions.
   BlockSequences(PangraphExportBlockSequencesArgs),
 
-  /// Export the core-genome alignment
+  /// Export the core-genome alignment. Note that alignment excludes insertions.
   CoreGenome(PangraphExportCoreAlignmentArgs),
 }
 

--- a/packages/pangraph/src/commands/export/export_block_sequences.rs
+++ b/packages/pangraph/src/commands/export/export_block_sequences.rs
@@ -8,7 +8,7 @@ use eyre::{Context, Report};
 
 #[derive(Parser, Debug, Default, Clone)]
 pub struct ExportBlockSequencesParams {
-  /// If set, then the full block sequences are exported but not aligned.
+  /// If set, then the full non-aligned block sequences are exported.
   #[clap(long)]
   pub unaligned: bool,
 }

--- a/packages/pangraph/src/commands/export/export_core_genome.rs
+++ b/packages/pangraph/src/commands/export/export_core_genome.rs
@@ -150,6 +150,35 @@ mod tests {
 
   #[test]
   fn test_core_block_aln_general_case() {
+    // path A: n1+, n2-
+    // path B: n4+, n5+, n3-
+
+    // block 1:
+    // cons: ACCTATCGTGATCGTTCGAT
+    // A n1: ACCTATCGT---CGTTCGAT
+    // B n3: ACTTATCGTGATCGTTCGAT
+    // reverse-complement:
+    // cons: ATCGAACGATCACGATAGGT
+    // A n1: ATCGAACG---ACGATAGGT
+    // B n3: ATCGAACGATCACGATAAGT
+
+    // block 2:
+    // cons: CTGCAA   GTCTGATCTAGTTA
+    // A n2: CTGCAATTTGTCTGATGTAGTTA
+    // B n4: CT--AA   GTCTGATCTAGTTA
+    // reverse-complement
+    // cons: TAACTAGATCAGAC   TTGCAG
+    // A n2: TAACTACATCAGACAAATTGCAG
+    // B n4: TAACTAGATCAGAC   TT--AG
+
+    // core (guide A):
+    // A: ACCTATCGT---CGTTCGATTAACTACATCAGACAAATTGCAG
+    // B: ACTTATCGTGATCGTTCGATTAACTAGATCAGAC   TT--AG
+
+    // core (guide B):
+    // A: CTGCAATTTGTCTGATGTAGTTAATCGAACG---ACGATAGGT
+    // B: CT--AA   GTCTGATCTAGTTAATCGAACGATCACGATAAGT
+
     let graph = Pangraph::from_str(indoc! {
     // language=json
     r#"
@@ -158,14 +187,14 @@ mod tests {
           "0": {
             "id": 0,
             "nodes": [1, 2],
-            "tot_len": 100,
+            "tot_len": 40,
             "circular": false,
             "name": "Path A"
           },
           "1": {
             "id": 1,
-            "nodes": [3, 4],
-            "tot_len": 100,
+            "nodes": [4, 5, 3],
+            "tot_len": 48,
             "circular": false,
             "name": "Path B"
           }
@@ -173,15 +202,15 @@ mod tests {
         "blocks": {
           "1": {
             "id": 1,
-            "consensus": "ACGTACGT",
+            "consensus": "ACCTATCGTGATCGTTCGAT",
             "alignments": {
               "1": {
                 "subs": [],
-                "dels": [],
+                "dels": [{"pos": 9, "len": 3}],
                 "inss": []
               },
-              "2": {
-                "subs": [{"pos": 3, "alt": "T"}],
+              "3": {
+                "subs": [{"pos": 2, "alt": "T"}],
                 "dels": [],
                 "inss": []
               }
@@ -189,17 +218,28 @@ mod tests {
           },
           "2": {
             "id": 2,
-            "consensus": "TTGCA",
+            "consensus": "CTGCAAGTCTGATCTAGTTA",
             "alignments": {
-              "3": {
-                "subs": [],
-                "dels": [{"pos": 2, "len": 1}],
-                "inss": []
+              "2": {
+                "subs": [{"pos": 13, "alt": "G"}],
+                "dels": [],
+                "inss": [{"pos": 6, "seq": "TTT"}]
               },
               "4": {
                 "subs": [],
+                "dels": [{"pos": 2, "len": 2}],
+                "inss": []
+              }
+            }
+          },
+          "3": {
+            "id": 3,
+            "consensus": "AGGCTACGAT",
+            "alignments": {
+              "5": {
+                "subs": [],
                 "dels": [],
-                "inss": [{"pos": 0, "seq": "AAA"}]
+                "inss": []
               }
             }
           }
@@ -210,28 +250,35 @@ mod tests {
             "block_id": 1,
             "path_id": 0,
             "strand": "+",
-            "position": [0, 8]
+            "position": [0, 17]
           },
           "2": {
             "id": 2,
-            "block_id": 1,
+            "block_id": 2,
             "path_id": 0,
             "strand": "-",
-            "position": [0, 8]
+            "position": [17, 40]
           },
           "3": {
             "id": 3,
-            "block_id": 2,
+            "block_id": 1,
             "path_id": 1,
-            "strand": "+",
-            "position": [0, 5]
+            "strand": "-",
+            "position": [28, 48]
           },
           "4": {
             "id": 4,
             "block_id": 2,
             "path_id": 1,
             "strand": "+",
-            "position": [0, 5]
+            "position": [0, 18]
+          },
+          "5": {
+            "id": 5,
+            "block_id": 3,
+            "path_id": 1,
+            "strand": "+",
+            "position": [18, 28]
           }
         }
       }
@@ -240,10 +287,55 @@ mod tests {
 
     let params = ExportCoreAlignmentParams {
       guide_strain: o!("Path A"),
+      unaligned: false,
+    };
+
+    let expected = vec![
+      (o!("Path A"), o!("ACCTATCGT---CGTTCGATTAACTACATCAGACTTGCAG")),
+      (o!("Path B"), o!("ACTTATCGTGATCGTTCGATTAACTAGATCAGACTT--AG")),
+    ];
+    let actual = core_block_aln(&graph, &params).unwrap();
+
+    assert_eq!(expected, actual);
+
+    let params = ExportCoreAlignmentParams {
+      guide_strain: o!("Path A"),
       unaligned: true,
     };
 
-    let expected = vec![(o!("Path A"), o!("ACGTTGTCA--")), (o!("Path B"), o!("TT--CGAATTTGCA"))];
+    let expected = vec![
+      (o!("Path A"), o!("ACCTATCGTCGTTCGATTAACTACATCAGACAAATTGCAG")),
+      (o!("Path B"), o!("ACTTATCGTGATCGTTCGATTAACTAGATCAGACTTAG")),
+    ];
+
+    let actual = core_block_aln(&graph, &params).unwrap();
+
+    assert_eq!(expected, actual);
+
+    let params = ExportCoreAlignmentParams {
+      guide_strain: o!("Path B"),
+      unaligned: false,
+    };
+
+    let expected = vec![
+      (o!("Path A"), o!("CTGCAAGTCTGATGTAGTTAATCGAACG---ACGATAGGT")),
+      (o!("Path B"), o!("CT--AAGTCTGATCTAGTTAATCGAACGATCACGATAAGT")),
+    ];
+
+    let actual = core_block_aln(&graph, &params).unwrap();
+
+    assert_eq!(expected, actual);
+
+    let params = ExportCoreAlignmentParams {
+      guide_strain: o!("Path B"),
+      unaligned: true,
+    };
+
+    let expected = vec![
+      (o!("Path A"), o!("CTGCAATTTGTCTGATGTAGTTAATCGAACGACGATAGGT")),
+      (o!("Path B"), o!("CTAAGTCTGATCTAGTTAATCGAACGATCACGATAAGT")),
+    ];
+
     let actual = core_block_aln(&graph, &params).unwrap();
 
     assert_eq!(expected, actual);

--- a/packages/pangraph/src/commands/root_args.rs
+++ b/packages/pangraph/src/commands/root_args.rs
@@ -36,14 +36,14 @@ fn styles() -> styling::Styles {
 #[clap(styles = styles())]
 /// Bioinformatic toolkit to align large sets of closely related genomes into a graph data structure.
 ///
-/// Finds homology amongst large collections of closely related genomes. The core of the algorithm partitions each genome into pancontigs that represent a sequence interval related by vertical descent. Each genome is then an ordered walk along pancontigs; the collection of all genomes form a graph that captures all observed structural diversity. The tool useful to parsimoniously infer horizontal gene transfer events within a community; perform comparative studies of genome gain, loss, and rearrangement dynamics; or simply to compress many related genomes.
+/// Finds homology amongst large collections of closely related genomes. The core of the algorithm partitions each genome into pancontigs (also called blocks) that represent a sequence interval related by vertical descent. Each genome is then an ordered walk along pancontigs. The collection of all genomes form a graph that captures all observed structural diversity. The tool useful to study structural variations in the genome, perform comparative studies of genome gain, loss, and rearrangement dynamics; or simply to compress many related genomes.
 ///
 ///
-/// Publication: "PanGraph: scalable bacterial pan-genome graph construction. Nicholas Noll, Marco Molari, Richard Neher. bioRxiv 2022.02.24.481757; doi: https://doi.org/10.1101/2022.02.24.481757"
+/// Publication: "PanGraph: scalable bacterial pan-genome graph construction."" Nicholas Noll, Marco Molari, Richard Neher. Microbial Genomics 9.6 (2023): 001034.; doi: https://doi.org/10.1099/mgen.0.001034"
 ///
 /// Documentation: https://pangraph.readthedocs.io/en/stable/
 ///
-/// Source code:https://github.com/neherlab/pangraph
+/// Source code: https://github.com/neherlab/pangraph
 ///
 /// Questions, ideas, bug reports: https://github.com/neherlab/pangraph/issues
 pub struct PangraphArgs {
@@ -71,10 +71,10 @@ pub enum PangraphCommands {
     args: PangraphExportArgs,
   },
 
-  /// Compute all pairwise marginalizations of a multiple sequence alignment graph
+  /// Generates a simplified graph that only contains a subset of the input genomes.
   Simplify(PangraphSimplifyArgs),
 
-  /// Reconstruct input fasta sequences from graph
+  /// Reconstruct all input fasta sequences from graph
   Reconstruct(PangraphReconstructArgs),
 
   /// Generate JSON schema for Pangraph file format

--- a/packages/pangraph/src/commands/simplify/simplify_args.rs
+++ b/packages/pangraph/src/commands/simplify/simplify_args.rs
@@ -2,7 +2,7 @@ use clap::{Parser, ValueHint};
 use std::fmt::Debug;
 use std::path::PathBuf;
 
-/// Computes all pairwise marginalizations of a multiple sequence alignment graph
+/// Generates a simplified graph that only contains a subset of the input genomes.
 #[derive(Parser, Debug)]
 pub struct PangraphSimplifyArgs {
   /// Path to Pangraph JSON.

--- a/packages/pangraph/src/io/fasta.rs
+++ b/packages/pangraph/src/io/fasta.rs
@@ -141,8 +141,8 @@ impl<'a> FastaReader<'a> {
     let fragment = self
       .line
       .chars()
-      .filter(|c| is_char_allowed(*c))
-      .map(|c| c.to_ascii_uppercase());
+      .map(|c| c.to_ascii_uppercase())
+      .filter(|c| is_char_allowed(*c));
 
     record.seq.extend(fragment);
 
@@ -157,8 +157,8 @@ impl<'a> FastaReader<'a> {
       let fragment = self
         .line
         .chars()
-        .filter(|c| is_char_allowed(*c))
-        .map(|c| c.to_ascii_uppercase());
+        .map(|c| c.to_ascii_uppercase())
+        .filter(|c| is_char_allowed(*c));
 
       record.seq.extend(fragment);
     }

--- a/packages/pangraph/src/io/gfa.rs
+++ b/packages/pangraph/src/io/gfa.rs
@@ -1,12 +1,12 @@
+use crate::circularize::circularize_utils::{Edge, SimpleNode};
 use crate::io::file::create_file_or_stdout;
 use crate::pangraph::pangraph::Pangraph;
 use crate::pangraph::pangraph_block::BlockId;
 use crate::pangraph::strand::Strand;
 use clap::Parser;
-use derive_more::Constructor;
 use eyre::{Context, Report};
 use itertools::Itertools;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::io::Write;
 use std::path::Path;
 
@@ -104,7 +104,22 @@ pub fn gfa_write<W: Write>(mut writer: W, g: &Pangraph, params: &GfaWriteParams)
     writeln!(writer, "# edges")?;
   }
 
-  for (edge, read_count) in &gfa.links.edge_ct {
+  for (edge, read_count) in gfa
+    .links
+    .edge_ct
+    .iter()
+    .map(|(edge, &read_count)| {
+      (
+        if edge.n1.bid > edge.n2.bid {
+          edge.invert()
+        } else {
+          *edge
+        },
+        read_count,
+      )
+    })
+    .sorted_by_key(|(edge, _)| (edge.n1.bid, edge.n2.bid))
+  {
     let bid1 = edge.n1.bid;
     let strand1 = edge.n1.strand;
     let bid2 = edge.n2.bid;
@@ -144,21 +159,9 @@ pub struct GfaSegment {
   duplicated: bool,
 }
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Constructor)]
-pub struct SimpleNode {
-  bid: BlockId,
-  strand: Strand,
-}
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Constructor)]
-pub struct Edge {
-  n1: SimpleNode,
-  n2: SimpleNode,
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct GfaLinks {
-  edge_ct: BTreeMap<Edge, usize>,
+  edge_ct: HashMap<Edge, usize>,
 }
 
 impl GfaLinks {
@@ -300,95 +303,144 @@ mod tests {
 
   #[test]
   fn test_gfa_general_case() {
+    // graph (circular):
+    // path A: 1+ -> 2- -> 3+
+    //         n1    n2    n3
+    // path B: 2+ -> 1- -> 3+ -> 4+
+    //         n4    n5    n6    n7
     let g = Pangraph::from_str(indoc! {
     // language=json
     r#"
-    {
-      "paths": {
-        "0": {
-          "id": 0,
-          "nodes": [
-            14515840915932838377
-          ],
-          "tot_len": 1737,
-          "circular": false,
-          "name": "Path A"
+      {
+        "paths": {
+          "0": {
+            "id": 0,
+            "nodes": [1, 2, 3],
+            "tot_len": 50,
+            "circular": true,
+            "name": "Path A"
+          },
+          "1": {
+            "id": 1,
+            "nodes": [4, 5, 6, 7],
+            "tot_len": 60,
+            "circular": true,
+            "name": "Path B"
+          }
         },
-        "1": {
-          "id": 1,
-          "nodes": [
-            15291847754458130853
-          ],
-          "tot_len": 1737,
-          "circular": false,
-          "name": "Path B"
-        },
-        "2": {
-          "id": 2,
-          "nodes": [
-            15109482180931348145
-          ],
-          "tot_len": 1737,
-          "circular": false,
-          "name": "Path C"
-        }
-      },
-      "blocks": {
-        "12778560093473594666": {
-          "id": 12778560093473594666,
-          "consensus": "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT",
-          "alignments": {
-            "14515840915932838377": {
-              "subs": [],
-              "dels": [],
-              "inss": []
-            },
-            "15291847754458130853": {
-              "subs": [],
-              "dels": [],
-              "inss": []
-            },
-            "15109482180931348145": {
-              "subs": [],
-              "dels": [],
-              "inss": []
+        "blocks": {
+          "1": {
+            "id": 1,
+            "consensus": "ACCTATCGTGATCGTTCGAT",
+            "alignments": {
+              "1": {
+                "subs": [],
+                "dels": [],
+                "inss": []
+              },
+              "4": {
+                "subs": [],
+                "dels": [],
+                "inss": []
+              }
+            }
+          },
+          "2": {
+            "id": 2,
+            "consensus": "CTGCAAGTCTGATCTAGTTA",
+            "alignments": {
+              "2": {
+                "subs": [],
+                "dels": [],
+                "inss": []
+              },
+              "6": {
+                "subs": [],
+                "dels": [],
+                "inss": []
+              }
+            }
+          },
+          "3": {
+            "id": 3,
+            "consensus": "AGGCTACGAT",
+            "alignments": {
+              "3": {
+                "subs": [],
+                "dels": [],
+                "inss": []
+              },
+              "5": {
+                "subs": [],
+                "dels": [],
+                "inss": []
+              }
+            }
+          },
+          "4": {
+            "id": 4,
+            "consensus": "CTTCAGCAAG",
+            "alignments": {
+              "7": {
+                "subs": [],
+                "dels": [],
+                "inss": []
+              }
             }
           }
-        }
-      },
-      "nodes": {
-        "14515840915932838377": {
-          "id": 14515840915932838377,
-          "block_id": 12778560093473594666,
-          "path_id": 0,
-          "strand": "+",
-          "position": [
-            0,
-            0
-          ]
         },
-        "15291847754458130853": {
-          "id": 15291847754458130853,
-          "block_id": 12778560093473594666,
-          "path_id": 1,
-          "strand": "+",
-          "position": [
-            0,
-            0
-          ]
-        },
-        "15109482180931348145": {
-          "id": 15109482180931348145,
-          "block_id": 12778560093473594666,
-          "path_id": 2,
-          "strand": "+",
-          "position": [
-            0,
-            0
-          ]
+        "nodes": {
+          "1": {
+            "id": 1,
+            "block_id": 1,
+            "path_id": 0,
+            "strand": "+",
+            "position": [0, 0]
+          },
+          "2": {
+            "id": 2,
+            "block_id": 2,
+            "path_id": 0,
+            "strand": "-",
+            "position": [0, 0]
+          },
+          "3": {
+            "id": 3,
+            "block_id": 3,
+            "path_id": 0,
+            "strand": "+",
+            "position": [0, 0]
+          },
+          "4": {
+            "id": 4,
+            "block_id": 2,
+            "path_id": 1,
+            "strand": "+",
+            "position": [0, 0]
+          },
+          "5": {
+            "id": 5,
+            "block_id": 1,
+            "path_id": 1,
+            "strand": "-",
+            "position": [0, 0]
+          },
+          "6": {
+            "id": 6,
+            "block_id": 3,
+            "path_id": 1,
+            "strand": "+",
+            "position": [0, 0]
+          },
+          "7": {
+            "id": 7,
+            "block_id": 4,
+            "path_id": 1,
+            "strand": "+",
+            "position": [0, 0]
+          }
         }
       }
-    }
     "#})
     .unwrap();
 
@@ -401,13 +453,21 @@ mod tests {
 
     let expected = indoc! {r#"
     H	VN:Z:1.0
-    S	12778560093473594666	ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT
-    L	A	-	B	+	1M
-    L	A	-	B	+	1M
-    L	A	-	B	+	1M
-    P	Path A	12778560093473594666	*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*
-    P	Path B	12778560093473594666	*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*
-    P	Path C	12778560093473594666	*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*
+    # blocks
+    S	1	ACCTATCGTGATCGTTCGAT	RC:i:40	LN:i:20
+    S	2	CTGCAAGTCTGATCTAGTTA	RC:i:40	LN:i:20
+    S	3	AGGCTACGAT	RC:i:20	LN:i:10
+    S	4	CTTCAGCAAG	RC:i:10	LN:i:10
+    # edges
+    L	1	+	2	-	*	RC:i:2
+    L	1	-	3	-	*	RC:i:1
+    L	1	-	3	+	*	RC:i:1
+    L	2	-	3	+	*	RC:i:1
+    L	2	-	4	-	*	RC:i:1
+    L	3	+	4	+	*	RC:i:1
+    # paths
+    P	Path A	1+,2-,3+	*	TP:Z:circular
+    P	Path B	2+,1-,3+,4+	*	TP:Z:circular
     "#};
 
     assert_eq!(expected, actual);

--- a/packages/pangraph/src/io/gfa.rs
+++ b/packages/pangraph/src/io/gfa.rs
@@ -108,7 +108,7 @@ pub fn gfa_write<W: Write>(mut writer: W, g: &Pangraph, params: &GfaWriteParams)
     .links
     .edge_ct
     .iter()
-    .map(|(edge, &read_count)| (edge.smaller_bid_first(), read_count)) // sort by smaller bid first
+    .map(|(edge, &read_count)| (edge.conventional_orientation(), read_count)) // sort by smaller bid first
     .sorted_by_key(|(edge, _)| edge.to_tuple())
   // sort by (bid1, bid2, strand1, strand2)
   {

--- a/packages/pangraph/src/io/gfa.rs
+++ b/packages/pangraph/src/io/gfa.rs
@@ -108,17 +108,9 @@ pub fn gfa_write<W: Write>(mut writer: W, g: &Pangraph, params: &GfaWriteParams)
     .links
     .edge_ct
     .iter()
-    .map(|(edge, &read_count)| {
-      (
-        if edge.n1.bid > edge.n2.bid {
-          edge.invert()
-        } else {
-          *edge
-        },
-        read_count,
-      )
-    })
-    .sorted_by_key(|(edge, _)| (edge.n1.bid, edge.n2.bid))
+    .map(|(edge, &read_count)| (edge.smaller_bid_first(), read_count)) // sort by smaller bid first
+    .sorted_by_key(|(edge, _)| edge.to_tuple())
+  // sort by (bid1, bid2, strand1, strand2)
   {
     let bid1 = edge.n1.bid;
     let strand1 = edge.n1.strand;
@@ -460,8 +452,8 @@ mod tests {
     S	4	CTTCAGCAAG	RC:i:10	LN:i:10
     # edges
     L	1	+	2	-	*	RC:i:2
-    L	1	-	3	-	*	RC:i:1
     L	1	-	3	+	*	RC:i:1
+    L	1	-	3	-	*	RC:i:1
     L	2	-	3	+	*	RC:i:1
     L	2	-	4	-	*	RC:i:1
     L	3	+	4	+	*	RC:i:1

--- a/packages/pangraph/src/pangraph/graph_merging.rs
+++ b/packages/pangraph/src/pangraph/graph_merging.rs
@@ -15,7 +15,7 @@ use crate::utils::interval::{have_no_overlap, Interval};
 use crate::utils::map_merge::{map_merge, ConflictResolution};
 use eyre::{Report, WrapErr};
 use itertools::Itertools;
-use log::{debug, trace};
+use log::{debug, trace, warn};
 use maplit::btreemap;
 use ordered_float::OrderedFloat;
 use rayon::prelude::*;
@@ -48,8 +48,15 @@ pub fn merge_graphs(
     graph = graph_new;
 
     // stop when no more mergers are possible
+    // or when the maximum number of iterations is reached
     if !has_changed {
       debug!("Graph merge {left_keys} <---> {right_keys} complete.");
+      break;
+    } else if i >= args.max_self_map {
+      warn!(
+        "Reached maximum number of self-merge iterations at graph merging {left_keys} <---> {right_keys}, consider increasing the current limit -x {}",
+        args.max_self_map
+      );
       break;
     }
     i += 1;


### PR DESCRIPTION
I updated the CLI help messages. And also
- removed the random `seed` for the build command (not used)
- removed the `-u` uppercase flag in the build command. Looking at the code I realized that we are [filtering for allowed characters](https://github.com/neherlab/pangraph/blob/7bc74005e8101ba0f37dc4fb63e70c245a9e70f7/packages/pangraph/src/io/fasta.rs#L144-L145) and then convert them to uppercase when reading fastas. The allowed characters are uppercase. I therefore inverted the uppercase conversion and the filtering, so that also lowercase inputs should work.
- I implemented the `-x` flag in the build command, which was not used so far.

(Nb: the branch is based on the PR #103)