### PR TITLE
Fix/empty nodes

### DIFF
--- a/packages/pangraph/src/circularize/circularize_utils.rs
+++ b/packages/pangraph/src/circularize/circularize_utils.rs
@@ -58,6 +58,25 @@ impl Edge {
   pub fn oriented_equal(&self, other: &Edge) -> bool {
     self.n1 == other.n1 && self.n2 == other.n2
   }
+
+  // orient such that the first node has a lower block id
+  // if block ids are equal, orient such that the first node has a forward strand
+  // if possible
+  pub fn conventional_orientation(&self) -> Edge {
+    if (self.n1.bid < self.n2.bid) || (self.n1.bid == self.n2.bid && self.n1.strand == Strand::Forward) {
+      *self
+    } else {
+      self.invert()
+    }
+  }
+
+  // returns a tuple (bid1, bid2, 0/1, 0/1) where 0/1 indicates the strand
+  // used to decide ordering between different edges
+  pub fn to_tuple(&self) -> (BlockId, BlockId, isize, isize) {
+    let s1 = if self.n1.strand == Strand::Forward { 0 } else { 1 };
+    let s2 = if self.n2.strand == Strand::Forward { 0 } else { 1 };
+    (self.n1.bid, self.n2.bid, s1, s2)
+  }
 }
 
 impl PartialEq for Edge {

--- a/packages/pangraph/src/pangraph/edits.rs
+++ b/packages/pangraph/src/pangraph/edits.rs
@@ -237,16 +237,22 @@ impl Edit {
     Ok(qry)
   }
 
+  /// Check if the alignment is empty, i.e. after applying the edits to the
+  /// consensus sequence, the resulting sequence is empty.
   pub fn is_empty_alignment(&self, consensus: impl AsRef<str>) -> bool {
     let cons_len = consensus.as_ref().len();
+    // if there are insertions, the alignment is not empty
     let insertions_len = self.inss.iter().map(|i| i.seq.len()).sum::<usize>();
     if insertions_len > 0 {
       return false;
     }
+    // if the total length of deletions is less than the length of the consensus
+    // sequence, the alignment is not empty
     let deletions_len = self.dels.iter().map(|d| d.len).sum::<usize>();
     if deletions_len < cons_len {
       return false;
     }
+    // otherwise, apply the edits and check if the resulting sequence is empty
     let seq_len = self.apply(consensus).unwrap().len();
     return seq_len == 0;
   }

--- a/packages/pangraph/src/pangraph/pangraph.rs
+++ b/packages/pangraph/src/pangraph/pangraph.rs
@@ -30,7 +30,8 @@ impl Pangraph {
     let block_id = BlockId(fasta.index);
     let block = PangraphBlock::from_consensus(fasta.seq, block_id, node_id);
     let path_id = PathId(fasta.index);
-    let node = PangraphNode::new(Some(node_id), block.id(), path_id, strand, (0, 0));
+    let node_position = if circular { (0, 0) } else { (0, tot_len) }; // path wraps around if circular
+    let node = PangraphNode::new(Some(node_id), block.id(), path_id, strand, node_position);
     let path = PangraphPath::new(Some(path_id), [node.id()], tot_len, circular, Some(fasta.seq_name));
     Self {
       blocks: btreemap! {block.id() => block},

--- a/packages/pangraph/src/pangraph/reweave.rs
+++ b/packages/pangraph/src/pangraph/reweave.rs
@@ -223,8 +223,11 @@ fn split_block(
   let b = &graph.blocks[&bid];
   for interval in intervals {
     let (b_slice, n_dict) = block_slice(b, &interval, graph);
-    for (old_nid, new_node) in n_dict {
-      u.n_new.entry(old_nid).or_default().push(new_node);
+    for (old_nid, new_node_opt) in n_dict {
+      // push to u.n_new entry if new_node is not empty
+      if let Some(new_node) = new_node_opt {
+        u.n_new.get_mut(&old_nid).unwrap().push(new_node);
+      }
     }
     if interval.aligned {
       h.push(ToMerge {

--- a/packages/pangraph/src/pangraph/reweave.rs
+++ b/packages/pangraph/src/pangraph/reweave.rs
@@ -528,9 +528,9 @@ mod tests {
         },
       );
 
-      let p1 = PangraphPath::new(Some(PathId(100)), [nid1], 2000, false, None);
-      let p2 = PangraphPath::new(Some(PathId(200)), [nid2], 2000, false, None);
-      let p3 = PangraphPath::new(Some(PathId(300)), [nid3], 200, false, None);
+      let p1 = PangraphPath::new(Some(PathId(100)), [nid1], 2000, true, None);
+      let p2 = PangraphPath::new(Some(PathId(200)), [nid2], 2000, true, None);
+      let p3 = PangraphPath::new(Some(PathId(300)), [nid3], 200, true, None);
 
       let G = Pangraph {
         paths: btreemap! {
@@ -683,9 +683,9 @@ mod tests {
       };
 
       let paths = btreemap! {
-        PathId(100) => PangraphPath::new(Some(PathId(100)), [NodeId(1), NodeId(2)], 1000, false, None),
-        PathId(200) => PangraphPath::new(Some(PathId(200)), [NodeId(3), NodeId(4), NodeId(5)], 1000, false, None),
-        PathId(300) => PangraphPath::new(Some(PathId(300)), [NodeId(6), NodeId(7), NodeId(8)], 1000, false, None),
+        PathId(100) => PangraphPath::new(Some(PathId(100)), [NodeId(1), NodeId(2)], 1000, true, None),
+        PathId(200) => PangraphPath::new(Some(PathId(200)), [NodeId(3), NodeId(4), NodeId(5)], 1000, true, None),
+        PathId(300) => PangraphPath::new(Some(PathId(300)), [NodeId(6), NodeId(7), NodeId(8)], 1000, true, None),
       };
 
       #[rustfmt::skip]

--- a/packages/pangraph/src/reconsensus/reconsensus.rs
+++ b/packages/pangraph/src/reconsensus/reconsensus.rs
@@ -4,7 +4,8 @@ use crate::pangraph::edits::{Ins, Sub};
 use crate::pangraph::pangraph::Pangraph;
 use crate::pangraph::pangraph_block::{BlockId, PangraphBlock};
 use crate::pangraph::pangraph_node::NodeId;
-use crate::reconsensus::remove_nodes::remove_emtpy_nodes;
+// use crate::reconsensus::remove_nodes::remove_emtpy_nodes;
+use crate::reconsensus::remove_nodes::find_empty_nodes;
 use crate::utils::collections::insert_at_inplace;
 use eyre::Report;
 use itertools::Itertools;
@@ -24,8 +25,12 @@ use std::collections::BTreeMap;
 ///     - for any in/del present in > M/2 sites, appends it to the consensus
 ///   - if the consensus has updated indels, then re-aligns all the sequences to the new consensus
 pub fn reconsensus_graph(graph: &mut Pangraph, ids_updated_blocks: Vec<BlockId>) -> Result<(), Report> {
-  // remove selected nodes from graph
-  remove_emtpy_nodes(graph, &ids_updated_blocks);
+  // // remove selected nodes from graph
+  // remove_emtpy_nodes(graph, &ids_updated_blocks);
+  debug_assert!(
+    find_empty_nodes(graph, &ids_updated_blocks).is_empty(),
+    "Empty nodes found in the graph"
+  );
 
   for block_id in ids_updated_blocks {
     let block = graph.blocks.get_mut(&block_id).unwrap();

--- a/packages/pangraph/src/reconsensus/remove_nodes.rs
+++ b/packages/pangraph/src/reconsensus/remove_nodes.rs
@@ -1,5 +1,3 @@
-use log::info;
-
 use crate::pangraph::pangraph::Pangraph;
 use crate::pangraph::pangraph_block::BlockId;
 use crate::pangraph::pangraph_node::NodeId;
@@ -22,51 +20,20 @@ fn find_empty_nodes(graph: &Pangraph, block_ids: &[BlockId]) -> Vec<NodeId> {
   let mut node_ids_to_delete = Vec::new();
   for &block_id in block_ids {
     let block = &graph.blocks[&block_id];
-    let cons_len = block.consensus_len();
+    let consensus = block.consensus();
+    let consensus_len = consensus.len();
 
     debug_assert!(
-      cons_len > 0,
+      consensus_len > 0,
       "Block {block_id} has a consensus length of 0 and should have been removed",
     );
 
     for (&node_id, edits) in block.alignments() {
       // check that edits are non-overlapping and well-defined
       #[cfg(any(test, debug_assertions))]
-      edits.sanity_check(cons_len).unwrap();
+      edits.sanity_check(consensus_len).unwrap();
 
-      //  if the node has insertions or substitutions, or the total deletion size is less than the consensus length
-      // then it is not empty
-      if !edits.inss.is_empty() || !edits.subs.is_empty() || edits.dels.is_empty() {
-        // check that the node is not empty
-        // first exclude edge-case: circular path with a single node. In this case start == end but the node is not empty
-        let path_id = graph.nodes[&node_id].path_id();
-        let path = &graph.paths[&path_id];
-        let is_circular = path.circular();
-        let single_node = path.nodes.len() == 1;
-        if is_circular && single_node {
-          debug_assert!(
-            path.tot_len > 0,
-            "Circular path {path_id} with a single node should not have a length of 0"
-          );
-          continue;
-        }
-
-        // if this is not the case, then it is sufficient to check that the node start != end
-        debug_assert!(
-          !graph.nodes[&node_id].start_is_end(),
-          "Node {node_id} with edits {edits:?} and consensus length {cons_len} is empty and should have been removed",
-        );
-
-        continue;
-      }
-
-      // if the node has no insertions or substitutions and the total deletion size is equal to the consensus length
-      // then it is empty and should be removed
-      if edits.dels.iter().map(|d| d.len).sum::<usize>() == cons_len {
-        info!(
-          "empty node {} with edits {:?} and consensus length {} is empty: to be removed",
-          node_id, edits, cons_len
-        );
+      if edits.is_empty_alignment(&consensus) {
         debug_assert!(graph.nodes[&node_id].start_is_end());
         node_ids_to_delete.push(node_id);
       }

--- a/packages/pangraph/src/reconsensus/remove_nodes.rs
+++ b/packages/pangraph/src/reconsensus/remove_nodes.rs
@@ -16,7 +16,7 @@ pub fn remove_emtpy_nodes(graph: &mut Pangraph, block_ids: &[BlockId]) {
 
 /// Finds nodes with empty sequences (full deletion) in the graph.
 /// It only checks specific blocks (the ones that were updated by a merger/split).
-fn find_empty_nodes(graph: &Pangraph, block_ids: &[BlockId]) -> Vec<NodeId> {
+pub fn find_empty_nodes(graph: &Pangraph, block_ids: &[BlockId]) -> Vec<NodeId> {
   let mut node_ids_to_delete = Vec::new();
   for &block_id in block_ids {
     let block = &graph.blocks[&block_id];


### PR DESCRIPTION
In the code the `block_slice` function takes care of slicing an alignment on an interval and return a new block with this sub-alignment. Occasionally this can produce an empty entry (when the slice covers a gap in the alignment). What we used to do was then finding all of these empty nodes and removing them afterwards.

I modified the code so that the `block_slice` function now returns an `Option`, which is `None` when a slice is empty. In this way empty nodes should never be produced, and it should not be needed to find and remove them afterwards.