### PR TITLE
Remove mash distance backend

### DIFF
--- a/docs/docs/usage/reference.md
+++ b/docs/docs/usage/reference.md
@@ -88,16 +88,16 @@ Align genomes into a multiple sequence alignment graph
 
    If the provided file path ends with one of the supported extensions: "gz", "bz2", "xz", "zst", then the file will be written compressed. If the required directory tree does not exist, it will be created.
 
-   Use "-" to write the uncompressed to standard output (stdout). This is the default, if the argument is not provided.
+   Use "-" to write the uncompressed data to standard output (stdout). This is the default, if the argument is not provided.
 
   Default value: `-`
 * `-l`, `--len <INDEL_LEN_THRESHOLD>` — Minimum block size for alignment graph (in nucleotides)
 
   Default value: `100`
-* `-a`, `--alpha <ALPHA>` — Energy cost for introducing junction due to alignment merger
+* `-a`, `--alpha <ALPHA>` — Energy cost for splitting a block during alignment merger. Controls graph fragmentation, see documentation
 
   Default value: `100`
-* `-b`, `--beta <BETA>` — Energy cost for interblock diversity due to alignment merger
+* `-b`, `--beta <BETA>` — Energy cost for diversity in the alignment. A high value prevents merging of distantly-related sequences in the same block, see documentation
 
   Default value: `10`
 * `-s`, `--sensitivity <SENSITIVITY>` — Used to set pairwise alignment sensitivity for minimap aligner. Corresponds to option -x asm5/asm10/asm20 in minimap2
@@ -105,24 +105,16 @@ Align genomes into a multiple sequence alignment graph
   Default value: `10`
 * `-K`, `--kmer-length <KMER_LENGTH>` — Sets kmer length for mmseqs2 aligner
 * `-c`, `--circular` — Toggle if input genomes are circular
-* `-u`, `--upper-case` — Transforms all sequences to upper case
 * `-x`, `--max-self-map <MAX_SELF_MAP>` — Maximum number of alignment rounds to consider per pairwise graph merger
 
   Default value: `100`
-* `-d`, `--distance-backend <DISTANCE_BACKEND>` — Backend to use for genome similarity estimation. Similarity impacts the guide tree
-
-  Default value: `native`
-
-  Possible values: `native`, `mash`
-
 * `-k`, `--alignment-kernel <ALIGNMENT_KERNEL>` — Backend to use for pairwise genome alignment
 
   Default value: `minimap2-lib`
 
   Possible values: `minimap2-lib`, `minimap2-cli`, `mmseqs`
 
-* `-f`, `--verify` — Verify that the original sequences can be reconstructed from the resulting pangraph
-* `--seed <SEED>` — Random seed for block id generation
+* `-f`, `--verify` — Sanity check: after construction verifies that the original sequences can be reconstructed exactly from the resulting pangraph. Raises an error otherwise
 
 
 

--- a/packages/pangraph/src/commands/build/build_args.rs
+++ b/packages/pangraph/src/commands/build/build_args.rs
@@ -12,18 +12,6 @@ use strum_macros::Display;
 #[clap(rename_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
-pub enum DistanceBackend {
-  #[default]
-  Native,
-  Mash,
-}
-
-#[derive(
-  Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, SmartDefault, Display, Serialize, Deserialize,
-)]
-#[clap(rename_all = "kebab-case")]
-#[serde(rename_all = "kebab-case")]
-#[strum(serialize_all = "kebab-case")]
 pub enum AlignmentBackend {
   #[default]
   Minimap2Lib,
@@ -67,11 +55,6 @@ pub struct PangraphBuildArgs {
   #[clap(long, short = 'x', default_value_t = 100)]
   #[clap(value_hint = ValueHint::Other)]
   pub max_self_map: usize,
-
-  /// Backend to use for genome similarity estimation. Similarity impacts the guide tree.
-  #[clap(long, short = 'd', default_value_t = DistanceBackend::default())]
-  #[clap(value_hint = ValueHint::Other)]
-  pub distance_backend: DistanceBackend,
 
   /// Backend to use for pairwise genome alignment
   #[clap(long, short = 'k',  default_value_t = AlignmentBackend::default())]

--- a/packages/pangraph/src/commands/build/build_run.rs
+++ b/packages/pangraph/src/commands/build/build_run.rs
@@ -50,7 +50,7 @@ pub fn build(fastas: Vec<FastaRecord>, args: &PangraphBuildArgs) -> Result<Pangr
     .collect_vec();
 
   // Build guide tree
-  let tree = build_tree_using_neighbor_joining(graphs, args)?;
+  let tree = build_tree_using_neighbor_joining(graphs)?;
 
   // Main loop: traverse the tree starting from leaf nodes and build the graphs bottom-up all the way to the root node.
   // The graph of the root node is the graph we are looking for.

--- a/packages/pangraph/src/reconsensus/reconsensus.rs
+++ b/packages/pangraph/src/reconsensus/reconsensus.rs
@@ -209,8 +209,6 @@ fn update_block_consensus(block: &mut PangraphBlock, consensus: &Seq) -> Result<
     }
   }
 
-  let consensus = consensus.into();
-
   // Re-align sequences
   let alignments = seqs
     .into_par_iter()

--- a/packages/pangraph/src/tree/neighbor_joining.rs
+++ b/packages/pangraph/src/tree/neighbor_joining.rs
@@ -34,6 +34,9 @@ pub fn build_tree_using_neighbor_joining(graphs: Vec<Pangraph>) -> Result<Lock<C
 }
 
 // Calculate pairwise distances between future guide tree nodes
+// Note: in previous version this function also took pangraph build command
+// arguments as input, and was responsible for switching between different
+// distance backents (mash vs native)
 fn calculate_distances(graphs: &[Pangraph]) -> Array2<f64> {
   let distances = mash_distance(graphs, &MinimizersParams::default());
   assert_eq!(distances.len_of(Axis(0)), distances.len_of(Axis(1)));

--- a/packages/pangraph/src/tree/neighbor_joining.rs
+++ b/packages/pangraph/src/tree/neighbor_joining.rs
@@ -1,6 +1,5 @@
 #![allow(non_snake_case)]
 
-use crate::commands::build::build_args::{DistanceBackend, PangraphBuildArgs};
 use crate::distance::mash::mash_distance::mash_distance;
 use crate::distance::mash::minimizer::MinimizersParams;
 use crate::pangraph::pangraph::Pangraph;
@@ -14,11 +13,8 @@ use ndarray::{s, Array1, Array2, Axis};
 use ndarray_stats::QuantileExt;
 
 /// Generate guide tree using neighbor joining method.
-pub fn build_tree_using_neighbor_joining(
-  graphs: Vec<Pangraph>,
-  args: &PangraphBuildArgs,
-) -> Result<Lock<Clade<Option<Pangraph>>>, Report> {
-  let mut distances = calculate_distances(&graphs, args);
+pub fn build_tree_using_neighbor_joining(graphs: Vec<Pangraph>) -> Result<Lock<Clade<Option<Pangraph>>>, Report> {
+  let mut distances = calculate_distances(&graphs);
 
   let mut nodes = graphs
     .into_iter()
@@ -38,16 +34,8 @@ pub fn build_tree_using_neighbor_joining(
 }
 
 // Calculate pairwise distances between future guide tree nodes
-fn calculate_distances(graphs: &[Pangraph], args: &PangraphBuildArgs) -> Array2<f64> {
-  let distances = match args.distance_backend {
-    // TODO: this function only needs sequences, and not graphs
-    DistanceBackend::Native => mash_distance(graphs, &MinimizersParams::default()),
-    DistanceBackend::Mash => {
-      // FIXME: what's the difference between Native and Mash?
-      unimplemented!("DistanceBackend::Mash");
-    }
-  };
-
+fn calculate_distances(graphs: &[Pangraph]) -> Array2<f64> {
+  let distances = mash_distance(graphs, &MinimizersParams::default());
   assert_eq!(distances.len_of(Axis(0)), distances.len_of(Axis(1)));
   distances
 }


### PR DESCRIPTION
Currently the mash distance backend is not implemented, and triggers an error if activated.

This option should be very rarely useful. Rather than implementing and having to include other optional dependencies, I removed the option altogether.