### PR TITLE
Fix simplify

### DIFF
--- a/packages/pangraph/src/pangraph/pangraph.rs
+++ b/packages/pangraph/src/pangraph/pangraph.rs
@@ -109,6 +109,23 @@ impl Pangraph {
         }
       }
     }
+
+    // remove empty blocks
+    let empty_blocks: Vec<BlockId> = self
+      .blocks
+      .iter()
+      .filter_map(|(bid, block)| {
+        if block.alignments().is_empty() {
+          Some(*bid)
+        } else {
+          None
+        }
+      })
+      .collect();
+
+    for bid in empty_blocks {
+      self.blocks.remove(&bid);
+    }
   }
 
   #[cfg(any(test, debug_assertions))]


### PR DESCRIPTION
This PR contains:
- a fix for the simplify command. When removing unneeded paths I was not removing potentially leftover empty blocks.
- a fix for the klebs dataset: the fasta identifier had id `>NZ_CP013711 <unknown description>`. I removed the `<unknown description>` tag. Otherwise the `--strains NZ_CP013711` flag for the simplify command would not recognize the path.

There is still a couple of small improvements that we could add:
- when parsing the name of paths from fasta files, should we drop the description?
- when running the simplify command, the name of the input file must come before the `--strains` option, otherwise the command does not detect the input. I.e.
```sh
pangraph simplify \
    klebs_pangraph.json \
    --strains NZ_CP013711,NC_017540 \
    > simplified_graph.json
```
works, but 
```sh
pangraph simplify \
    --strains NZ_CP013711,NC_017540 \
    klebs_pangraph.json \
    > simplified_graph.json
```
doesn't work.
Is there a fix for this or should we just specify better in the documentation that this order should be respected?