### PR TITLE
Debug/improve aln

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 Thumbs.db
 __pycache__/
 ehthumbs.db
+/debug

--- a/packages/pangraph/src/align/nextclade/align/align.rs
+++ b/packages/pangraph/src/align/nextclade/align/align.rs
@@ -257,4 +257,43 @@ mod tests {
     .unwrap();
     assert!(alignment.hit_boundary);
   }
+
+  #[test]
+  fn test_align_nuc_simplestripe_unaligned() {
+    let aln_ref = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA------------------";
+    let aln_qry = "-------------------------------------GGGGGGGGGGGGGGGGGG";
+    let qry_str = aln_qry.replace('-', "");
+    let ref_str = aln_ref.replace('-', "");
+    let qry_seq = to_nuc_seq(&qry_str).unwrap();
+    let ref_seq = to_nuc_seq(&ref_str).unwrap();
+    let aln_ref = to_nuc_seq(&aln_ref).unwrap();
+    let aln_qry = to_nuc_seq(&aln_qry).unwrap();
+
+    let params = NextalignParams {
+      max_alignment_attempts: 1,
+      min_length: 3,
+      ..Default::default()
+    };
+    let gap_open_close = get_gap_open_close_scores_flat(&ref_seq, &params);
+    let mean_shift = 70;
+    let initial_bandwidth = 0;
+    let alignment = align_nuc_simplestripe(
+      &qry_seq,
+      &ref_seq,
+      &gap_open_close,
+      mean_shift,
+      initial_bandwidth,
+      &params,
+    )
+    .unwrap();
+
+    let expected = AlignmentOutput {
+      qry_seq: aln_qry,
+      ref_seq: aln_ref,
+      alignment_score: 0,
+      hit_boundary: false,
+      is_reverse_complement: false,
+    };
+    assert_eq!(alignment, expected);
+  }
 }

--- a/packages/pangraph/src/align/nextclade/align/align.rs
+++ b/packages/pangraph/src/align/nextclade/align/align.rs
@@ -45,9 +45,9 @@ pub fn align_nuc_simplestripe(
     );
   }
 
-  debug!(
-    "In nucleotide alignment: Aligning sequences of lengths: query: {qry_len}, reference: {ref_len}, with mean_shift: {mean_shift}, initial_bandwidth: {initial_bandwidth}"
-  );
+  // debug!(
+  //   "In nucleotide alignment: Aligning sequences of lengths: query: {qry_len}, reference: {ref_len}, with mean_shift: {mean_shift}, initial_bandwidth: {initial_bandwidth}"
+  // );
 
   let mut band_width = initial_bandwidth;
   let mut stripes = simple_stripes(mean_shift, band_width, ref_len, qry_len);
@@ -56,10 +56,10 @@ pub fn align_nuc_simplestripe(
   let mut alignment = align_pairwise(qry_seq, ref_seq, gap_open_close, params, &stripes);
 
   while alignment.hit_boundary && attempt < params.max_alignment_attempts {
-    debug!(
-      "In nucleotide alignment: Band boundary is hit on attempt {}. Retrying with relaxed parameters. Alignment score was: {}",
-      attempt, alignment.alignment_score
-    );
+    // debug!(
+    //   "In nucleotide alignment: Band boundary is hit on attempt {}. Retrying with relaxed parameters. Alignment score was: {}",
+    //   attempt, alignment.alignment_score
+    // );
     // double bandwidth parameters or increase to one if 0
     band_width = max(2 * band_width, max(1, mean_shift.unsigned_abs() as usize));
     stripes = simple_stripes(mean_shift, band_width, ref_len, qry_len);
@@ -75,10 +75,10 @@ pub fn align_nuc_simplestripe(
       attempt, alignment.alignment_score
     );
   } else if attempt > 0 {
-    debug!(
-      "In nucleotide alignment: Succeeded without hitting band boundary on attempt {}. Alignment score was: {}",
-      attempt, alignment.alignment_score
-    );
+    // debug!(
+    //   "In nucleotide alignment: Succeeded without hitting band boundary on attempt {}. Alignment score was: {}",
+    //   attempt, alignment.alignment_score
+    // );
   }
   Ok(alignment)
 }

--- a/packages/pangraph/src/align/nextclade/align_with_nextclade.rs
+++ b/packages/pangraph/src/align/nextclade/align_with_nextclade.rs
@@ -56,14 +56,20 @@ pub fn align_with_nextclade(
   // but they are recorded as limits in the alignment range.
   // We need to add them manually.
   let mut deletions = deletions;
-  if alignment_range.begin.inner > 0 {
-    deletions.push(NucDelRange::from_usize(0, alignment_range.begin.inner as usize));
-  }
-  if (alignment_range.end.inner as usize) < ref_seq.len() {
-    deletions.push(NucDelRange::from_usize(
-      alignment_range.end.inner as usize,
-      ref_seq.len(),
-    ));
+  if let Some(alignment_range) = alignment_range {
+    if alignment_range.begin.inner > 0 {
+      deletions.push(NucDelRange::from_usize(0, alignment_range.begin.inner as usize));
+    }
+    if (alignment_range.end.inner as usize) < ref_seq.len() {
+      deletions.push(NucDelRange::from_usize(
+        alignment_range.end.inner as usize,
+        ref_seq.len(),
+      ));
+    }
+  } else {
+    // If alignment_range is None, it means that there is not interval alignable.
+    // We need to add a deletion covering the whole reference sequence.
+    deletions.push(NucDelRange::from_usize(0, ref_seq.len()));
   }
 
   Ok(AlignWithNextcladeOutput {
@@ -303,7 +309,7 @@ mod tests {
       substitutions: vec![],
       deletions: vec![NucDelRange::from_usize(0, 37)], // Should delete entire reference
       insertions: vec![Insertion {
-        pos: 37,
+        pos: 36,
         ins: to_nuc_seq("GGGGGGGGGGGGGGGGGG")?,
       }],
       is_reverse_complement: false,

--- a/packages/pangraph/src/align/nextclade/analyze/nuc_changes.rs
+++ b/packages/pangraph/src/align/nextclade/analyze/nuc_changes.rs
@@ -4,10 +4,11 @@ use crate::align::nextclade::analyze::nuc_del::NucDelRange;
 use crate::align::nextclade::analyze::nuc_sub::NucSub;
 use crate::align::nextclade::coord::range::NucRefGlobalRange;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FindNucChangesOutput {
   pub substitutions: Vec<NucSub>,
   pub deletions: Vec<NucDelRange>,
-  pub alignment_range: NucRefGlobalRange,
+  pub alignment_range: Option<NucRefGlobalRange>,
 }
 
 /// Finds nucleotide changes (nucleotide substitutions and deletions) as well
@@ -58,9 +59,119 @@ pub fn find_nuc_changes(qry_aln: &[Nuc], ref_aln: &[Nuc]) -> FindNucChangesOutpu
   substitutions.sort();
   deletions.sort();
 
+  let alignment_range = if alignment_start >= 0 && alignment_end >= 0 {
+    Some(NucRefGlobalRange::from_usize(
+      alignment_start as usize,
+      alignment_end as usize,
+    ))
+  } else {
+    None
+  };
+
   FindNucChangesOutput {
     substitutions,
     deletions,
-    alignment_range: NucRefGlobalRange::from_usize(alignment_start as usize, alignment_end as usize),
+    alignment_range,
+  }
+}
+#[cfg(test)]
+mod tests {
+
+  use super::*;
+  use crate::align::nextclade::alphabet::nuc::to_nuc_seq;
+
+  use eyre::Report;
+  use pretty_assertions::assert_eq;
+  use rstest::rstest;
+
+  // Simple test with no differences between query and reference.
+  #[rstest]
+  fn test_find_nuc_changes_no_differences() -> Result<(), Report> {
+    // Assuming Nuc can be created from characters and that a gap is represented by Nuc::gap().
+    // The implementation of Nuc::from(char) and Nuc::gap() is expected.
+    let ref_aln = to_nuc_seq("GGGGGGGGGGGGGGGGGG")?;
+    let qry_aln = to_nuc_seq("GGGGGGGGGGGGGGGGGG")?;
+
+    let result = find_nuc_changes(&qry_aln, &ref_aln);
+    let expected_result = FindNucChangesOutput {
+      substitutions: vec![],
+      deletions: vec![],
+      alignment_range: Some(NucRefGlobalRange::from_usize(0, 18)),
+    };
+    assert_eq!(result, expected_result);
+
+    Ok(())
+  }
+
+  // Test with a single substitution.
+  #[rstest]
+  fn test_find_nuc_changes_single_substitution() -> Result<(), Report> {
+    let ref_aln = to_nuc_seq("GGGGGGGGGGGGGGGGGG")?;
+    let qry_aln = to_nuc_seq("GGGAGGGGGGGGGGGGGG")?;
+
+    let result = find_nuc_changes(&qry_aln, &ref_aln);
+    let expected_result = FindNucChangesOutput {
+      substitutions: vec![NucSub {
+        ref_nuc: Nuc::G,
+        pos: 3.into(),
+        qry_nuc: Nuc::A,
+      }],
+      deletions: vec![],
+      alignment_range: Some(NucRefGlobalRange::from_usize(0, 18)),
+    };
+    assert_eq!(result, expected_result);
+
+    Ok(())
+  }
+
+  // test with deletion in query
+  #[rstest]
+  fn test_find_nuc_changes_single_deletion() -> Result<(), Report> {
+    let ref_aln = to_nuc_seq("GGGGGGGGGGGGGGGGGG")?;
+    let qry_aln = to_nuc_seq("GGG--GGGGGGGGGGGGG")?;
+
+    let result = find_nuc_changes(&qry_aln, &ref_aln);
+    let expected_result = FindNucChangesOutput {
+      substitutions: vec![],
+      deletions: vec![NucDelRange::from_usize(3, 5)],
+      alignment_range: Some(NucRefGlobalRange::from_usize(0, 18)),
+    };
+    assert_eq!(result, expected_result);
+
+    Ok(())
+  }
+
+  // test for deletion at the beginning / end of the query
+  #[rstest]
+  fn test_find_nuc_changes_deletion_at_edges() -> Result<(), Report> {
+    let ref_aln = to_nuc_seq("GGGGGGGGGGGGGGGGGGG")?;
+    let qry_aln = to_nuc_seq("--GGGGGGGGGGGGGGG--")?;
+
+    let result = find_nuc_changes(&qry_aln, &ref_aln);
+    let expected_result = FindNucChangesOutput {
+      substitutions: vec![],
+      deletions: vec![],
+      alignment_range: Some(NucRefGlobalRange::from_usize(2, 17)),
+    };
+    assert_eq!(result, expected_result);
+
+    Ok(())
+  }
+
+  // test with fully deleted query
+  #[rstest]
+  fn test_find_nuc_changes_full_deletion() -> Result<(), Report> {
+    let ref_aln = to_nuc_seq("GGGGGGGGGGGGGGGGGG")?;
+    let qry_aln = to_nuc_seq("------------------")?;
+
+    let result = find_nuc_changes(&qry_aln, &ref_aln);
+    let expected_result = FindNucChangesOutput {
+      substitutions: vec![],
+      deletions: vec![],
+      alignment_range: None,
+    };
+    assert_eq!(result, expected_result);
+
+    Ok(())
   }
 }

--- a/packages/pangraph/src/bin/merge_two_graphs.rs
+++ b/packages/pangraph/src/bin/merge_two_graphs.rs
@@ -4,12 +4,12 @@ use eyre::{Report, WrapErr};
 use log::info;
 use pangraph::commands::build::build_args::PangraphBuildArgs;
 use pangraph::commands::reconstruct::reconstruct_run::{compare_sequences, reconstruct};
-use pangraph::io::fasta::read_many_fasta;
 use pangraph::io::json::{JsonPretty, json_write_file};
 use pangraph::pangraph::graph_merging::merge_graphs;
 use pangraph::pangraph::pangraph::Pangraph;
 use pangraph::utils::global_init::global_init;
 use pangraph::utils::global_init::setup_logger;
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 #[ctor]
@@ -31,9 +31,9 @@ struct Args {
   #[clap(value_hint = ValueHint::FilePath)]
   pub right_graph: Option<PathBuf>,
 
+  // binary flag: if set, verify the sequences in the merged graph did not change
   #[clap(long, short = 'V')]
-  #[clap(value_hint = ValueHint::FilePath)]
-  pub verify_seqs: Option<PathBuf>,
+  pub merge_verify: bool,
 }
 
 fn main() -> Result<(), Report> {
@@ -71,21 +71,33 @@ fn main() -> Result<(), Report> {
 
   json_write_file(&args.build_args.output_json, &merged, JsonPretty(true))?;
 
-  // verify
-  if let Some(verify_seqs_path) = args.verify_seqs {
-    info!("Verifying merged graph against {:?}", verify_seqs_path);
-    let mut seqs = reconstruct(&merged);
-    // read sequences into a list
-    let verify_seqs = read_many_fasta(&[verify_seqs_path])?;
+  if args.merge_verify {
+    let initial_left_seqs = reconstruct(&left);
+    let initial_right_seqs = reconstruct(&right);
 
-    seqs.try_for_each(|actual| -> Result<(), Report> {
-      let actual = actual?;
-      // look for sequence with the expected index
-      let idx = actual.index;
-      let expected = &verify_seqs[idx];
-      compare_sequences(&expected, &actual)?;
+    // create a map of {seq.idx -> seq}
+    let mut initial_seqs = HashMap::new();
+    initial_left_seqs
+      .chain(initial_right_seqs)
+      .try_for_each(|seq| -> Result<(), Report> {
+        let seq = seq?;
+        initial_seqs.insert(seq.index, seq);
+        Ok(())
+      })?;
+
+    // verify that the merged graph contains the same sequences
+    let mut merged_seqs = reconstruct(&merged);
+    merged_seqs.try_for_each(|seq| -> Result<(), Report> {
+      let seq = seq?;
+      let idx = seq.index;
+      if let Some(expected) = initial_seqs.get(&idx) {
+        compare_sequences(expected, &seq)?;
+      } else {
+        return Err(eyre::eyre!("Sequence with index {idx} not found in initial sequences").into());
+      }
       Ok(())
     })?;
+    info!("Merged graph contains the same sequences as the original graphs");
   }
 
   Ok(())


### PR DESCRIPTION
fixes a bug with an edge case of block merging, that happens when a specific query sequence cannot be aligned to the block consensus. The bug was loosing track of a deletion. Now solved by:
- letting the [`find_nuc_changes`](https://github.com/neherlab/pangraph/blob/fadbd8cecf41ffe85e0c92d8eb4d13ad4a1fe8e6/packages/pangraph/src/align/nextclade/analyze/nuc_changes.rs#L17) function optionally return an empty alignment range
- [adding a deletion](https://github.com/neherlab/pangraph/blob/2fa6b001f0467756b6773221318a8934739540aa/packages/pangraph/src/align/nextclade/align_with_nextclade.rs#L69-L73) when the alignment range is empty

I also added tests to cover the edge cases and the added functionalities.

In the future it might be advisable to add an extra step where these sequences are a posteriori removed from the block.