### PR TITLE
refactor: reimplement positions_to_intervals

### DIFF
--- a/packages/pangraph/src/utils/interval.rs
+++ b/packages/pangraph/src/utils/interval.rs
@@ -193,4 +193,100 @@ mod tests {
     // Duplicates should be merged into a single contiguous interval.
     assert_eq!(intervals, vec![Interval::new(5, 9)]);
   }
+
+  #[test]
+  fn test_positions_to_intervals_single_position_at_zero() {
+    let intervals = positions_to_intervals(&[0]);
+    assert_eq!(intervals, vec![Interval::new(0, 1)]);
+  }
+
+  #[test]
+  fn test_positions_to_intervals_two_contiguous() {
+    let intervals = positions_to_intervals(&[7, 8]);
+    assert_eq!(intervals, vec![Interval::new(7, 9)]);
+  }
+
+  #[test]
+  fn test_positions_to_intervals_two_non_contiguous() {
+    let intervals = positions_to_intervals(&[5, 10]);
+    assert_eq!(intervals, vec![Interval::new(5, 6), Interval::new(10, 11)]);
+  }
+
+  #[test]
+  fn test_positions_to_intervals_starting_from_zero() {
+    let intervals = positions_to_intervals(&[0, 1, 2, 3]);
+    assert_eq!(intervals, vec![Interval::new(0, 4)]);
+  }
+
+  #[test]
+  fn test_positions_to_intervals_gap_of_one() {
+    let intervals = positions_to_intervals(&[1, 3, 5, 7]);
+    assert_eq!(
+      intervals,
+      vec![
+        Interval::new(1, 2),
+        Interval::new(3, 4),
+        Interval::new(5, 6),
+        Interval::new(7, 8)
+      ]
+    );
+  }
+
+  #[test]
+  fn test_positions_to_intervals_large_gaps() {
+    let intervals = positions_to_intervals(&[1, 100, 1000]);
+    assert_eq!(
+      intervals,
+      vec![Interval::new(1, 2), Interval::new(100, 101), Interval::new(1000, 1001)]
+    );
+  }
+
+  #[test]
+  fn test_positions_to_intervals_mixed_contiguous_and_gaps() {
+    let intervals = positions_to_intervals(&[1, 2, 3, 10, 11, 20]);
+    assert_eq!(
+      intervals,
+      vec![
+        Interval::new(1, 4),   // 1,2,3 -> [1,4)
+        Interval::new(10, 12), // 10,11 -> [10,12)
+        Interval::new(20, 21)  // 20 -> [20,21)
+      ]
+    );
+  }
+
+  #[test]
+  fn test_positions_to_intervals_all_duplicates() {
+    let intervals = positions_to_intervals(&[42, 42, 42, 42]);
+    assert_eq!(intervals, vec![Interval::new(42, 43)]);
+  }
+
+  #[test]
+  fn test_positions_to_intervals_complex_duplicates_with_gaps() {
+    let intervals = positions_to_intervals(&[1, 1, 3, 3, 3, 7, 8, 8, 9]);
+    assert_eq!(
+      intervals,
+      vec![
+        Interval::new(1, 2),  // 1,1 -> [1,2)
+        Interval::new(3, 4),  // 3,3,3 -> [3,4)
+        Interval::new(7, 10)  // 7,8,8,9 -> [7,10)
+      ]
+    );
+  }
+
+  #[test]
+  fn test_positions_to_intervals_many_single_intervals() {
+    let intervals = positions_to_intervals(&[1, 3, 5, 7, 9, 11, 13]);
+    assert_eq!(
+      intervals,
+      vec![
+        Interval::new(1, 2),
+        Interval::new(3, 4),
+        Interval::new(5, 6),
+        Interval::new(7, 8),
+        Interval::new(9, 10),
+        Interval::new(11, 12),
+        Interval::new(13, 14)
+      ]
+    );
+  }
 }

--- a/packages/pangraph/src/utils/interval.rs
+++ b/packages/pangraph/src/utils/interval.rs
@@ -157,41 +157,6 @@ mod tests {
   }
 
   #[test]
-  fn test_positions_to_intervals_list_contiguous() {
-    let intervals = positions_to_intervals(&[1, 2, 3, 4, 5]);
-    assert_eq!(intervals, vec![Interval::new(1, 6)]);
-  }
-
-  #[test]
-  fn test_positions_to_intervals_list_non_contiguous() {
-    let intervals = positions_to_intervals(&[1, 3, 5]);
-    assert_eq!(
-      intervals,
-      vec![Interval::new(1, 2), Interval::new(3, 4), Interval::new(5, 6)]
-    );
-  }
-
-  #[test]
-  fn test_positions_to_intervals_list_unsorted() {
-    let intervals = positions_to_intervals(&[10, 1, 2, 3, 20, 21]);
-    assert_eq!(
-      intervals,
-      vec![
-        Interval::new(1, 4),   // from 1 to 3 -> [1,4)
-        Interval::new(10, 11), // singleton [10,11)
-        Interval::new(20, 22)  // 20 and 21 merge into [20,22)
-      ]
-    );
-  }
-
-  #[test]
-  fn test_positions_to_intervals_list_duplicates() {
-    let intervals = positions_to_intervals(&[5, 5, 5, 6, 7, 7, 8]);
-    // Duplicates should be merged into a single contiguous interval.
-    assert_eq!(intervals, vec![Interval::new(5, 9)]);
-  }
-
-  #[test]
   fn test_positions_to_intervals_single_position_at_zero() {
     let intervals = positions_to_intervals(&[0]);
     assert_eq!(intervals, vec![Interval::new(0, 1)]);
@@ -210,13 +175,28 @@ mod tests {
   }
 
   #[test]
+  fn test_positions_to_intervals_list_contiguous() {
+    let intervals = positions_to_intervals(&[1, 2, 3, 4, 5]);
+    assert_eq!(intervals, vec![Interval::new(1, 6)]);
+  }
+
+  #[test]
   fn test_positions_to_intervals_starting_from_zero() {
     let intervals = positions_to_intervals(&[0, 1, 2, 3]);
     assert_eq!(intervals, vec![Interval::new(0, 4)]);
   }
 
   #[test]
-  fn test_positions_to_intervals_gap_of_one() {
+  fn test_positions_to_intervals_large_gaps() {
+    let intervals = positions_to_intervals(&[1, 100, 1000]);
+    assert_eq!(
+      intervals,
+      vec![Interval::new(1, 2), Interval::new(100, 101), Interval::new(1000, 1001)]
+    );
+  }
+
+  #[test]
+  fn test_positions_to_intervals_list_non_contiguous() {
     let intervals = positions_to_intervals(&[1, 3, 5, 7]);
     assert_eq!(
       intervals,
@@ -230,12 +210,23 @@ mod tests {
   }
 
   #[test]
-  fn test_positions_to_intervals_large_gaps() {
-    let intervals = positions_to_intervals(&[1, 100, 1000]);
+  fn test_positions_to_intervals_list_unsorted() {
+    let intervals = positions_to_intervals(&[10, 21, 1, 2, 3, 20]);
     assert_eq!(
       intervals,
-      vec![Interval::new(1, 2), Interval::new(100, 101), Interval::new(1000, 1001)]
+      vec![
+        Interval::new(1, 4),   // from 1 to 3 -> [1,4)
+        Interval::new(10, 11), // singleton [10,11)
+        Interval::new(20, 22)  // 20 and 21 merge into [20,22)
+      ]
     );
+  }
+
+  #[test]
+  fn test_positions_to_intervals_list_duplicates() {
+    let intervals = positions_to_intervals(&[5, 5, 5, 6, 7, 7, 8]);
+    // Duplicates should be merged into a single contiguous interval.
+    assert_eq!(intervals, vec![Interval::new(5, 9)]);
   }
 
   #[test]
@@ -266,23 +257,6 @@ mod tests {
         Interval::new(1, 2),  // 1,1 -> [1,2)
         Interval::new(3, 4),  // 3,3,3 -> [3,4)
         Interval::new(7, 10)  // 7,8,8,9 -> [7,10)
-      ]
-    );
-  }
-
-  #[test]
-  fn test_positions_to_intervals_many_single_intervals() {
-    let intervals = positions_to_intervals(&[1, 3, 5, 7, 9, 11, 13]);
-    assert_eq!(
-      intervals,
-      vec![
-        Interval::new(1, 2),
-        Interval::new(3, 4),
-        Interval::new(5, 6),
-        Interval::new(7, 8),
-        Interval::new(9, 10),
-        Interval::new(11, 12),
-        Interval::new(13, 14)
       ]
     );
   }

--- a/packages/pangraph/src/utils/interval.rs
+++ b/packages/pangraph/src/utils/interval.rs
@@ -139,25 +139,25 @@ mod tests {
   }
 
   #[test]
-  fn test_from_position_list_empty() {
+  fn test_positions_to_intervals_list_empty() {
     let intervals = positions_to_intervals(&[]);
     assert!(intervals.is_empty());
   }
 
   #[test]
-  fn test_from_position_list_single() {
+  fn test_positions_to_intervals_list_single() {
     let intervals = positions_to_intervals(&[5]);
     assert_eq!(intervals, vec![Interval::new(5, 6)]);
   }
 
   #[test]
-  fn test_from_position_list_contiguous() {
+  fn test_positions_to_intervals_list_contiguous() {
     let intervals = positions_to_intervals(&[1, 2, 3, 4, 5]);
     assert_eq!(intervals, vec![Interval::new(1, 6)]);
   }
 
   #[test]
-  fn test_from_position_list_non_contiguous() {
+  fn test_positions_to_intervals_list_non_contiguous() {
     let intervals = positions_to_intervals(&[1, 3, 5]);
     assert_eq!(
       intervals,
@@ -166,7 +166,7 @@ mod tests {
   }
 
   #[test]
-  fn test_from_position_list_unsorted() {
+  fn test_positions_to_intervals_list_unsorted() {
     let intervals = positions_to_intervals(&[10, 1, 2, 3, 20, 21]);
     assert_eq!(
       intervals,
@@ -179,7 +179,7 @@ mod tests {
   }
 
   #[test]
-  fn test_from_position_list_duplicates() {
+  fn test_positions_to_intervals_list_duplicates() {
     let intervals = positions_to_intervals(&[5, 5, 5, 6, 7, 7, 8]);
     // Duplicates should be merged into a single contiguous interval.
     assert_eq!(intervals, vec![Interval::new(5, 9)]);

--- a/packages/pangraph/src/utils/interval.rs
+++ b/packages/pangraph/src/utils/interval.rs
@@ -140,31 +140,25 @@ mod tests {
 
   #[test]
   fn test_from_position_list_empty() {
-    let positions: Vec<usize> = vec![];
-    let intervals = positions_to_intervals(&positions);
+    let intervals = positions_to_intervals(&[]);
     assert!(intervals.is_empty());
   }
 
   #[test]
   fn test_from_position_list_single() {
-    let positions = vec![5];
-    let intervals = positions_to_intervals(&positions);
+    let intervals = positions_to_intervals(&[5]);
     assert_eq!(intervals, vec![Interval::new(5, 6)]);
   }
 
   #[test]
   fn test_from_position_list_contiguous() {
-    let positions = vec![1, 2, 3, 4, 5];
-    let intervals = positions_to_intervals(&positions);
-    // [1, 5] becomes [1, 6) as our intervals are half-open.
+    let intervals = positions_to_intervals(&[1, 2, 3, 4, 5]);
     assert_eq!(intervals, vec![Interval::new(1, 6)]);
   }
 
   #[test]
   fn test_from_position_list_non_contiguous() {
-    let positions = vec![1, 3, 5];
-    let intervals = positions_to_intervals(&positions);
-    // Each position stands alone.
+    let intervals = positions_to_intervals(&[1, 3, 5]);
     assert_eq!(
       intervals,
       vec![Interval::new(1, 2), Interval::new(3, 4), Interval::new(5, 6)]
@@ -173,9 +167,7 @@ mod tests {
 
   #[test]
   fn test_from_position_list_unsorted() {
-    let positions = vec![10, 1, 2, 3, 20, 21];
-    let intervals = positions_to_intervals(&positions);
-    // After sorting: [1,2,3,10,20,21]
+    let intervals = positions_to_intervals(&[10, 1, 2, 3, 20, 21]);
     assert_eq!(
       intervals,
       vec![
@@ -188,8 +180,7 @@ mod tests {
 
   #[test]
   fn test_from_position_list_duplicates() {
-    let positions = vec![5, 5, 5, 6, 7, 7, 8];
-    let intervals = positions_to_intervals(&positions);
+    let intervals = positions_to_intervals(&[5, 5, 5, 6, 7, 7, 8]);
     // Duplicates should be merged into a single contiguous interval.
     assert_eq!(intervals, vec![Interval::new(5, 9)]);
   }


### PR DESCRIPTION
I find this slightly more readable, but perhaps I am biased towards functional-style programming.

This should probably be slightly more efficient - it avoids extra memory allocations for sorted vec, and then dynamically growing it. Not that important probably, but why not.



Tests are mostly AI-generated, take care!