### PR TITLE
feat: add --extra-band-width and --max-alignment-attempts

### DIFF
--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -129,6 +129,12 @@ Align genomes into a multiple sequence alignment graph
 
 * `-f`, `--verify` — Sanity check: after construction verifies that the original sequences can be reconstructed exactly from the resulting pangraph. Raises an error otherwise
 * `--no-progress-bar` — Toggle to disable progress bar. Notice that the progress bar is only displayed if the output is specified via the `-o` argument
+* `--extra-band-width <EXTRA_BAND_WIDTH>` — Excess bandwidth for internal stripes
+
+  Default value: `5`
+* `--max-alignment-attempts <MAX_ALIGNMENT_ATTEMPTS>` — Number of times Nextclade will retry alignment with more relaxed results if alignment band boundaries are hit
+
+  Default value: `4`
 
 
 

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -129,10 +129,10 @@ Align genomes into a multiple sequence alignment graph
 
 * `-f`, `--verify` — Sanity check: after construction verifies that the original sequences can be reconstructed exactly from the resulting pangraph. Raises an error otherwise
 * `--no-progress-bar` — Toggle to disable progress bar. Notice that the progress bar is only displayed if the output is specified via the `-o` argument
-* `--extra-band-width <EXTRA_BAND_WIDTH>` — Excess bandwidth for internal stripes
+* `--extra-band-width <EXTRA_BAND_WIDTH>` — For within-block alignment: excess bandwidth for internal stripes. Can be increased to improve block alignment quality, at the cost of computation time and memory usage
 
   Default value: `5`
-* `--max-alignment-attempts <MAX_ALIGNMENT_ATTEMPTS>` — Number of times Nextclade will retry alignment with more relaxed results if alignment band boundaries are hit
+* `--max-alignment-attempts <MAX_ALIGNMENT_ATTEMPTS>` — For within-block alignment: number of times Nextclade will retry alignment with more relaxed results if alignment band boundaries are hit
 
   Default value: `4`
 

--- a/packages/pangraph/src/align/map_variations.rs
+++ b/packages/pangraph/src/align/map_variations.rs
@@ -1,21 +1,30 @@
 use crate::align::nextclade::align_with_nextclade::{AlignWithNextcladeOutput, NextalignParams, align_with_nextclade};
 use crate::align::nextclade::alphabet::nuc::{from_nuc, from_nuc_seq};
+use crate::commands::build::build_args::PangraphBuildArgs;
 use crate::pangraph::edits::{Del, Edit, Ins, Sub};
 use crate::representation::seq::Seq;
 use eyre::Report;
 use itertools::Itertools;
 
-pub fn map_variations(ref_seq: &Seq, qry_seq: &Seq, mean_shift: i32, bandwidth: usize) -> Result<Edit, Report> {
+pub fn map_variations(
+  ref_seq: &Seq,
+  qry_seq: &Seq,
+  mean_shift: i32,
+  mut bandwidth: usize,
+  args: &PangraphBuildArgs,
+) -> Result<Edit, Report> {
   let params = NextalignParams {
     min_length: 1,
+    max_alignment_attempts: args.max_alignment_attempts,
     ..NextalignParams::default()
   };
+
+  bandwidth += args.extra_band_width;
 
   let AlignWithNextcladeOutput {
     substitutions,
     deletions,
     insertions,
-    // hit_boundary,
     ..
   } = align_with_nextclade(ref_seq.as_str(), qry_seq.as_str(), mean_shift, bandwidth, &params)?;
 
@@ -58,7 +67,14 @@ mod tests {
 
     let mean_shift = -2;
     let bandwidth = 3;
-    let actual = map_variations(&Seq::from(r), &Seq::from(q), mean_shift, bandwidth).unwrap();
+    let actual = map_variations(
+      &Seq::from(r),
+      &Seq::from(q),
+      mean_shift,
+      bandwidth,
+      &PangraphBuildArgs::default(),
+    )
+    .unwrap();
 
     let expected = Edit {
       subs: vec![Sub::new(6, 'A')],
@@ -94,7 +110,14 @@ mod tests {
     let q = "CTGATTTAGTCCCTTAGGGGTTACTCTACACTGTAG";
     let mean_shift = 2;
     let bandwidth = 2;
-    let actual = map_variations(&Seq::from(r), &Seq::from(q), mean_shift, bandwidth).unwrap();
+    let actual = map_variations(
+      &Seq::from(r),
+      &Seq::from(q),
+      mean_shift,
+      bandwidth,
+      &PangraphBuildArgs::default(),
+    )
+    .unwrap();
 
     let expected = Edit {
       subs: vec![Sub::new(10, 'A')],
@@ -130,7 +153,14 @@ mod tests {
     let q = "CCTGACACTGATTTAGTCCTAGGGGTTACTCTACACCGTAGCCTAGCCGCCG";
     let mean_shift = -4;
     let bandwidth = 2;
-    let actual = map_variations(&Seq::from(r), &Seq::from(q), mean_shift, bandwidth).unwrap();
+    let actual = map_variations(
+      &Seq::from(r),
+      &Seq::from(q),
+      mean_shift,
+      bandwidth,
+      &PangraphBuildArgs::default(),
+    )
+    .unwrap();
 
     let expected = Edit {
       subs: vec![Sub::new(10, 'A'), Sub::new(31, 'C')],
@@ -165,7 +195,14 @@ mod tests {
     let q = "CGCCCTACTACAAGAGGGAACGGGGGGGGGGGGGAAGTATAGCCACAATAGCTGG";
     let mean_shift = -2;
     let bandwidth = 11;
-    let actual = map_variations(&Seq::from(r), &Seq::from(q), mean_shift, bandwidth).unwrap();
+    let actual = map_variations(
+      &Seq::from(r),
+      &Seq::from(q),
+      mean_shift,
+      bandwidth,
+      &PangraphBuildArgs::default(),
+    )
+    .unwrap();
 
     let expected = Edit {
       subs: vec![],

--- a/packages/pangraph/src/commands/build/build_args.rs
+++ b/packages/pangraph/src/commands/build/build_args.rs
@@ -19,7 +19,7 @@ pub enum AlignmentBackend {
 }
 
 /// Align genomes into a pangenome graph
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, SmartDefault)]
 pub struct PangraphBuildArgs {
   /// Path(s) to zero, one or multiple FASTA files with input sequences. Multiple records within one file are treated as separate genomes.
   ///
@@ -59,7 +59,7 @@ pub struct PangraphBuildArgs {
   ///
   /// Nb: `mmseqs` is more sensitive to highly-diverged sequences, but slower and requires more memory.
   /// It is not provided with Pangraph, so you need to install it separately (see: https://github.com/soedinglab/MMseqs2)
-  #[clap(long, short = 'k',  default_value_t = AlignmentBackend::default())]
+  #[clap(long, short = 'k',  default_value_t = PangraphBuildArgs::default().alignment_kernel)]
   #[clap(value_hint = ValueHint::Other)]
   pub alignment_kernel: AlignmentBackend,
 
@@ -70,4 +70,16 @@ pub struct PangraphBuildArgs {
   /// Toggle to disable progress bar. Notice that the progress bar is only displayed if the output is specified via the `-o` argument.
   #[clap(long)]
   pub no_progress_bar: bool,
+
+  /// Excess bandwidth for internal stripes.
+  #[default = 5]
+  #[clap(long, default_value_t = PangraphBuildArgs::default().extra_band_width)]
+  #[clap(value_hint = ValueHint::Other)]
+  pub extra_band_width: usize,
+
+  /// Number of times Nextclade will retry alignment with more relaxed results if alignment band boundaries are hit
+  #[default = 4]
+  #[clap(long, default_value_t = PangraphBuildArgs::default().max_alignment_attempts)]
+  #[clap(value_hint = ValueHint::Other)]
+  pub max_alignment_attempts: usize,
 }

--- a/packages/pangraph/src/commands/build/build_args.rs
+++ b/packages/pangraph/src/commands/build/build_args.rs
@@ -71,13 +71,14 @@ pub struct PangraphBuildArgs {
   #[clap(long)]
   pub no_progress_bar: bool,
 
-  /// Excess bandwidth for internal stripes.
+  /// For within-block alignment: excess bandwidth for internal stripes.
+  /// Can be increased to improve block alignment quality, at the cost of computation time and memory usage.
   #[default = 5]
   #[clap(long, default_value_t = PangraphBuildArgs::default().extra_band_width)]
   #[clap(value_hint = ValueHint::Other)]
   pub extra_band_width: usize,
 
-  /// Number of times Nextclade will retry alignment with more relaxed results if alignment band boundaries are hit
+  /// For within-block alignment: number of times Nextclade will retry alignment with more relaxed results if alignment band boundaries are hit.
   #[default = 4]
   #[clap(long, default_value_t = PangraphBuildArgs::default().max_alignment_attempts)]
   #[clap(value_hint = ValueHint::Other)]

--- a/packages/pangraph/src/pangraph/graph_merging.rs
+++ b/packages/pangraph/src/pangraph/graph_merging.rs
@@ -145,7 +145,7 @@ pub fn self_merge(graph: Pangraph, args: &PangraphBuildArgs) -> Result<(Pangraph
     .into_par_iter()
     .map(|mut merge_promise| {
       merge_promise
-        .solve_promise()
+        .solve_promise(args)
         .wrap_err_with(|| format!("When solving merge promise: {merge_promise:#?}"))
     })
     .collect::<Result<Vec<_>, _>>()?;
@@ -166,7 +166,7 @@ pub fn self_merge(graph: Pangraph, args: &PangraphBuildArgs) -> Result<(Pangraph
 
   // update consensus and alignment of merged blocks.
   let merge_block_ids = new_blocks_dict.keys().copied().collect_vec();
-  reconsensus_graph(&mut graph, merge_block_ids).wrap_err("During reconsensus")?;
+  reconsensus_graph(&mut graph, merge_block_ids, args).wrap_err("During reconsensus")?;
 
   Ok((graph, true))
 }

--- a/packages/pangraph/src/pangraph/reweave.rs
+++ b/packages/pangraph/src/pangraph/reweave.rs
@@ -1,6 +1,7 @@
 use crate::align::alignment::{Alignment, AnchorBlock, ExtractedHit};
 use crate::align::bam::cigar::{Side, add_flanking_indel, cigar_switch_ref_qry, invert_cigar};
 use crate::align::map_variations::map_variations;
+use crate::commands::build::build_args::PangraphBuildArgs;
 use crate::io::seq::reverse_complement;
 use crate::make_internal_error;
 use crate::pangraph::edits::Edit;
@@ -36,7 +37,7 @@ impl MergePromise {
     }
   }
 
-  pub fn solve_promise(&mut self) -> Result<PangraphBlock, Report> {
+  pub fn solve_promise(&mut self, args: &PangraphBuildArgs) -> Result<PangraphBlock, Report> {
     // TODO: avoid re-aligning if cigar is only a single match (no indels)
 
     // calculate the mean shift and bandwidth of the alignment due to the displacement
@@ -78,7 +79,7 @@ impl MergePromise {
           let mean_shift = cigar_mean_shift + edits_mean_shift;
           let bandwidth = cigar_bandwidth + edits_bandwidth;
 
-            map_variations(self.anchor_block.consensus(), &seq, mean_shift, bandwidth)
+            map_variations(self.anchor_block.consensus(), &seq, mean_shift, bandwidth, args)
             .wrap_err_with(|| {
               format!(
               "during map variation:\ncigar mean shift: {}\ncigar bandwidth: {}\nedits mean shift: {}\nedits bandwidth: {}\ncigar: {:?}\nedits: {:?}",


### PR DESCRIPTION
This exposes previously hardcoded Nextclade-related params`EXTRA_BANDWIDTH` and `MAX_ALIGNMENT_ATTEMPTS` as CLI args of `pangraph build` command.

`max_alignment_attempts`is already a param of Nextclade, so it gets merged into the `NextalignParams`.

However, Nextclade is unaware of `extra_band_width`, so it gets added to the band width value directly. We may or may not backport this to Nextclade (adding it to `NextalignParams`).