### PR TITLE
Feat/band parameters

### DIFF
--- a/packages/pangraph/src/align/map_variations.rs
+++ b/packages/pangraph/src/align/map_variations.rs
@@ -40,7 +40,7 @@ impl BandParameters {
 pub fn map_variations(
   ref_seq: &Seq,
   qry_seq: &Seq,
-  band_params: BandParameters,
+  mut band_params: BandParameters,
   args: &PangraphBuildArgs,
 ) -> Result<Edit, Report> {
   let params = NextalignParams {
@@ -49,21 +49,14 @@ pub fn map_variations(
     ..NextalignParams::default()
   };
 
-  let mut bandwidth = band_params.band_width;
-  bandwidth += args.extra_band_width;
+  band_params.band_width += args.extra_band_width;
 
   let AlignWithNextcladeOutput {
     substitutions,
     deletions,
     insertions,
     ..
-  } = align_with_nextclade(
-    ref_seq.as_str(),
-    qry_seq.as_str(),
-    band_params.mean_shift,
-    bandwidth,
-    &params,
-  )?;
+  } = align_with_nextclade(ref_seq.as_str(), qry_seq.as_str(), band_params, &params)?;
 
   let subs = substitutions
     .iter()

--- a/packages/pangraph/src/align/nextclade/align/align.rs
+++ b/packages/pangraph/src/align/nextclade/align/align.rs
@@ -1,3 +1,4 @@
+use crate::align::map_variations::BandParameters;
 use crate::align::nextclade::align::backtrace::{AlignmentOutput, backtrace};
 use crate::align::nextclade::align::band_2d::Stripe;
 use crate::align::nextclade::align::band_2d::{full_matrix, simple_stripes};
@@ -32,8 +33,7 @@ pub fn align_nuc_simplestripe(
   qry_seq: &[Nuc],
   ref_seq: &[Nuc],
   gap_open_close: &[i32],
-  mean_shift: i32,
-  initial_bandwidth: usize,
+  band_params: BandParameters,
   params: &NextalignParams,
 ) -> Result<AlignmentOutput<Nuc>, Report> {
   let qry_len = qry_seq.len();
@@ -45,7 +45,8 @@ pub fn align_nuc_simplestripe(
     );
   }
 
-  let mut band_width = initial_bandwidth;
+  let mut band_width = band_params.band_width();
+  let mean_shift = band_params.mean_shift();
   let mut stripes = simple_stripes(mean_shift, band_width, ref_len, qry_len);
 
   let mut attempt = 1;
@@ -205,43 +206,16 @@ mod tests {
     };
     let gap_open_close = get_gap_open_close_scores_flat(&ref_seq, &params);
 
-    let mean_shift = -30;
-    let initial_bandwidth = 1;
-    let alignment = align_nuc_simplestripe(
-      &qry_seq,
-      &ref_seq,
-      &gap_open_close,
-      mean_shift,
-      initial_bandwidth,
-      &params,
-    )
-    .unwrap();
+    let band_params = BandParameters::new(-30, 1);
+    let alignment = align_nuc_simplestripe(&qry_seq, &ref_seq, &gap_open_close, band_params, &params).unwrap();
     assert!(!alignment.hit_boundary);
 
-    let mean_shift = 0;
-    let initial_bandwidth = 31;
-    let alignment = align_nuc_simplestripe(
-      &qry_seq,
-      &ref_seq,
-      &gap_open_close,
-      mean_shift,
-      initial_bandwidth,
-      &params,
-    )
-    .unwrap();
+    let band_params = BandParameters::new(0, 31);
+    let alignment = align_nuc_simplestripe(&qry_seq, &ref_seq, &gap_open_close, band_params, &params).unwrap();
     assert!(!alignment.hit_boundary);
 
-    let mean_shift = 0;
-    let initial_bandwidth = 30;
-    let alignment = align_nuc_simplestripe(
-      &qry_seq,
-      &ref_seq,
-      &gap_open_close,
-      mean_shift,
-      initial_bandwidth,
-      &params,
-    )
-    .unwrap();
+    let band_params = BandParameters::new(0, 30);
+    let alignment = align_nuc_simplestripe(&qry_seq, &ref_seq, &gap_open_close, band_params, &params).unwrap();
     assert!(alignment.hit_boundary);
   }
 
@@ -262,17 +236,8 @@ mod tests {
       ..Default::default()
     };
     let gap_open_close = get_gap_open_close_scores_flat(&ref_seq, &params);
-    let mean_shift = 70;
-    let initial_bandwidth = 0;
-    let alignment = align_nuc_simplestripe(
-      &qry_seq,
-      &ref_seq,
-      &gap_open_close,
-      mean_shift,
-      initial_bandwidth,
-      &params,
-    )
-    .unwrap();
+    let band_params = BandParameters::new(70, 0);
+    let alignment = align_nuc_simplestripe(&qry_seq, &ref_seq, &gap_open_close, band_params, &params).unwrap();
 
     let expected = AlignmentOutput {
       qry_seq: aln_qry,

--- a/packages/pangraph/src/align/nextclade/align_with_nextclade.rs
+++ b/packages/pangraph/src/align/nextclade/align_with_nextclade.rs
@@ -1,3 +1,4 @@
+use crate::align::map_variations::BandParameters;
 use crate::align::nextclade::align::align::align_nuc_simplestripe;
 use crate::align::nextclade::align::gap_open::get_gap_open_close_scores_flat;
 use crate::align::nextclade::align::insertions_strip::{Insertion, insertions_strip};
@@ -23,8 +24,7 @@ pub struct AlignWithNextcladeOutput {
 pub fn align_with_nextclade(
   reff: impl AsRef<str>,
   qry: impl AsRef<str>,
-  mean_shift: i32,
-  bandwidth: usize,
+  band_params: BandParameters,
   params: &NextalignParams,
 ) -> Result<AlignWithNextcladeOutput, Report> {
   let ref_seq = to_nuc_seq(reff.as_ref()).wrap_err("When converting reference sequence")?;
@@ -32,7 +32,7 @@ pub fn align_with_nextclade(
 
   let gap_open_close = get_gap_open_close_scores_flat(&ref_seq, params);
 
-  let alignment = align_nuc_simplestripe(&qry_seq, &ref_seq, &gap_open_close, mean_shift, bandwidth, params)
+  let alignment = align_nuc_simplestripe(&qry_seq, &ref_seq, &gap_open_close, band_params, params)
     .wrap_err("When aligning sequences with nextclade align")?;
 
   let stripped = insertions_strip(&alignment.qry_seq, &alignment.ref_seq);
@@ -102,9 +102,8 @@ mod tests {
       ..NextalignParams::default()
     };
 
-    let mean_shift = 0;
-    let bandwidth = 4 + *EXTRA_BANDWIDTH;
-    let actual = align_with_nextclade(ref_seq, qry_seq, mean_shift, bandwidth, &params)?;
+    let band_params = BandParameters::new(0, 4 + *EXTRA_BANDWIDTH);
+    let actual = align_with_nextclade(ref_seq, qry_seq, band_params, &params)?;
 
     let expected = AlignWithNextcladeOutput {
       qry_aln,
@@ -163,9 +162,8 @@ mod tests {
       min_length: 3,
       ..NextalignParams::default()
     };
-    let mean_shift = 0;
-    let bandwidth = *EXTRA_BANDWIDTH;
-    let actual = align_with_nextclade(ref_seq, qry_seq, mean_shift, bandwidth, &params)?;
+    let band_params = BandParameters::new(0, *EXTRA_BANDWIDTH);
+    let actual = align_with_nextclade(ref_seq, qry_seq, band_params, &params)?;
 
     let expected = AlignWithNextcladeOutput {
       qry_aln,
@@ -231,9 +229,8 @@ mod tests {
       ..NextalignParams::default()
     };
 
-    let mean_shift = 0;
-    let bandwidth = *EXTRA_BANDWIDTH;
-    let actual = align_with_nextclade(ref_seq, qry_seq, mean_shift, bandwidth, &params)?;
+    let band_params = BandParameters::new(0, *EXTRA_BANDWIDTH);
+    let actual = align_with_nextclade(ref_seq, qry_seq, band_params, &params)?;
 
     let subs = [
       (9, Nuc::A),
@@ -292,10 +289,9 @@ mod tests {
       ..NextalignParams::default()
     };
 
-    let mean_shift = 70;
-    let bandwidth = *EXTRA_BANDWIDTH;
+    let band_params = BandParameters::new(70, *EXTRA_BANDWIDTH);
 
-    let actual = align_with_nextclade(ref_seq, qry_seq, mean_shift, bandwidth, &params)?;
+    let actual = align_with_nextclade(ref_seq, qry_seq, band_params, &params)?;
 
     // TODO: What the correct result should be:
     let expected = AlignWithNextcladeOutput {

--- a/packages/pangraph/src/bin/nextclade_example.rs
+++ b/packages/pangraph/src/bin/nextclade_example.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, ValueHint};
 use ctor::ctor;
 use eyre::Report;
+use pangraph::align::map_variations::BandParameters;
 use pangraph::align::nextclade::align_with_nextclade::{NextalignParams, align_with_nextclade};
 use pangraph::io::fasta::{read_many_fasta, read_one_fasta};
 use pangraph::utils::global_init::{global_init, setup_logger};
@@ -41,10 +42,11 @@ fn main() -> Result<(), Report> {
     max_alignment_attempts: 1,
     ..Default::default()
   };
+  let band_params = BandParameters::new(mean_shift, bandwidth);
 
   let qry_records = read_many_fasta(&input_query_fastas)?;
   for qry_record in qry_records {
-    let result = align_with_nextclade(&ref_record.seq, &qry_record.seq, mean_shift, bandwidth, &params)?;
+    let result = align_with_nextclade(&ref_record.seq, &qry_record.seq, band_params, &params)?;
     println!("{:#?}", &result);
   }
 


### PR DESCRIPTION
- packaged `mean_shift` and `bandwidth` into a single object `BandParameters`.
- simplified the `map_variations()` function logic, moving the shift and bandwidth calculations into the `from_edits` method of `BandParameters` 